### PR TITLE
Added link to the correct version of mupen64 to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The latest release of Stroop can be downloaded from our [Releases Page](https://
   * Windows 10 / Windows 8 / Windows 7 / Windows Vista 64-bit or 32-bit
   * OpenGL 3.0 or greater (requirement for map tab only)
   * .NET Framework 4.6 (See [.NET Framework System Requirements](https://msdn.microsoft.com/en-us/library/8z6watww(v=vs.110).aspx) for more information)
-  * Mupen 0.5 rerecording (0.5.1 will not work)
+  * [Mupen 0.5 rerecording](http://adelikat.tasvideos.org/emulatordownloads/mupen64-rr/Mupen64%20v8%20installer.zip) (0.5.1 will not work)
   * 64 Marios (Must be super)
   * Marios must be American (No PAL or JAP just yet)
   


### PR DESCRIPTION
Found the link in #7 after also googling 'mupen64 0.5' and finding the version on emutalk.net that doesn't work. To avoid future confusion and downloading exes from random forums I suggest adding the link to the readme or rehosting it in the repository so it can be found later.