### PR TITLE
disable 'prefer 32 bit' for all configurations

### DIFF
--- a/Source/SM64 Diagnostic/SM64 Diagnostic.csproj
+++ b/Source/SM64 Diagnostic/SM64 Diagnostic.csproj
@@ -53,6 +53,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup>
     <ApplicationIcon>icon.ico</ApplicationIcon>
@@ -71,7 +72,7 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-    <Prefer32Bit>true</Prefer32Bit>
+    <Prefer32Bit>false</Prefer32Bit>
     <GenerateSerializationAssemblies>Auto</GenerateSerializationAssemblies>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>


### PR DESCRIPTION
Disable 'prefer 32 bit' because it gave an exception when trying to connect to Bizhawk.