### PR TITLE
Add Gfx tab

### DIFF
--- a/STROOP/Config/Config.xml
+++ b/STROOP/Config/Config.xml
@@ -3,7 +3,7 @@
   <Emulators>
     <Emulator name="Mupen 5.0 RR" processName="mupen64-rerecording" ramStart="0x008EBA80"/>
     <Emulator name="Nemu64 0.8" processName="Nemu64" ramStart="0x10020000"/>
-    <Emulator name="BizHawk" processName="EmuHawk" offsetDll="mupen64plus.dll" ramStart="0x691C0"/>
+    <Emulator name="BizHawk" processName="EmuHawk" offsetDll="mupen64plus.dll" ramStart="0x6C370"/>
   </Emulators>
 
   <!-- US, JP, or PAL -->

--- a/STROOP/Enums/BaseAddressTypeEnum.cs
+++ b/STROOP/Enums/BaseAddressTypeEnum.cs
@@ -34,5 +34,6 @@ namespace STROOP.Structs
         Area,
         HackedArea,
         CamHack,
+        GfxNode,
     };
 }

--- a/STROOP/Forms/StroopMainForm.Designer.cs
+++ b/STROOP/Forms/StroopMainForm.Designer.cs
@@ -1061,6 +1061,8 @@ namespace STROOP
             this.splitContainerGfxLeft = new System.Windows.Forms.SplitContainer();
             this.treeViewGfx = new System.Windows.Forms.TreeView();
             this.splitContainerGfxRight = new System.Windows.Forms.SplitContainer();
+            this.splitContainerGfxMiddle = new System.Windows.Forms.SplitContainer();
+            this.buttonGfxRefresh = new System.Windows.Forms.Button();
             this.watchVariablePanelGfx = new STROOP.Controls.WatchVariablePanel();
             this.richTextBoxGfx = new System.Windows.Forms.RichTextBox();
             this.labelVersionNumber = new System.Windows.Forms.Label();
@@ -1079,8 +1081,8 @@ namespace STROOP
             this.buttonShowRightPane = new System.Windows.Forms.Button();
             this.buttonShowLeftRightPane = new System.Windows.Forms.Button();
             this.buttonShowLeftPane = new System.Windows.Forms.Button();
-            this.splitContainerGfxMiddle = new System.Windows.Forms.SplitContainer();
-            this.buttonGfxRefresh = new System.Windows.Forms.Button();
+            this.buttonGfxRefreshObject = new System.Windows.Forms.Button();
+            this.buttonGfxDumpDisplayList = new System.Windows.Forms.Button();
             this.groupBoxObjects.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.trackBarObjSlotSize)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainerMain)).BeginInit();
@@ -1419,11 +1421,11 @@ namespace STROOP
             this.splitContainerGfxRight.Panel1.SuspendLayout();
             this.splitContainerGfxRight.Panel2.SuspendLayout();
             this.splitContainerGfxRight.SuspendLayout();
-            this.panelConnect.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainerGfxMiddle)).BeginInit();
             this.splitContainerGfxMiddle.Panel1.SuspendLayout();
             this.splitContainerGfxMiddle.Panel2.SuspendLayout();
             this.splitContainerGfxMiddle.SuspendLayout();
+            this.panelConnect.SuspendLayout();
             this.SuspendLayout();
             // 
             // labelProcessSelect
@@ -1453,7 +1455,7 @@ namespace STROOP
             this.groupBoxObjects.Margin = new System.Windows.Forms.Padding(2);
             this.groupBoxObjects.Name = "groupBoxObjects";
             this.groupBoxObjects.Padding = new System.Windows.Forms.Padding(2);
-            this.groupBoxObjects.Size = new System.Drawing.Size(923, 378);
+            this.groupBoxObjects.Size = new System.Drawing.Size(923, 379);
             this.groupBoxObjects.TabIndex = 2;
             this.groupBoxObjects.TabStop = false;
             this.groupBoxObjects.Text = "Objects";
@@ -1518,7 +1520,7 @@ namespace STROOP
             this.WatchVariablePanelObjects.Location = new System.Drawing.Point(4, 45);
             this.WatchVariablePanelObjects.Margin = new System.Windows.Forms.Padding(2);
             this.WatchVariablePanelObjects.Name = "WatchVariablePanelObjects";
-            this.WatchVariablePanelObjects.Size = new System.Drawing.Size(915, 156);
+            this.WatchVariablePanelObjects.Size = new System.Drawing.Size(915, 157);
             this.WatchVariablePanelObjects.TabIndex = 0;
             this.WatchVariablePanelObjects.Resize += new System.EventHandler(this.WatchVariablePanelObjects_Resize);
             // 
@@ -4711,7 +4713,7 @@ namespace STROOP
             this.tableLayoutPanelFile.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 20F));
             this.tableLayoutPanelFile.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 20F));
             this.tableLayoutPanelFile.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 20F));
-            this.tableLayoutPanelFile.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 222F));
+            this.tableLayoutPanelFile.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 223F));
             this.tableLayoutPanelFile.Controls.Add(this.textBoxTableRow15Col10, 10, 14);
             this.tableLayoutPanelFile.Controls.Add(this.textBoxTableRow14Col10, 10, 13);
             this.tableLayoutPanelFile.Controls.Add(this.textBoxTableRow13Col10, 10, 12);
@@ -8907,7 +8909,7 @@ namespace STROOP
             this.glControlMap.Location = new System.Drawing.Point(4, 3);
             this.glControlMap.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.glControlMap.Name = "glControlMap";
-            this.glControlMap.Size = new System.Drawing.Size(705, 454);
+            this.glControlMap.Size = new System.Drawing.Size(708, 454);
             this.glControlMap.TabIndex = 0;
             this.glControlMap.VSync = false;
             this.glControlMap.Load += new System.EventHandler(this.glControlMap_Load);
@@ -9874,7 +9876,7 @@ namespace STROOP
             // 
             this.splitContainerModelTables.Panel2.Controls.Add(this.labelModelTriangles);
             this.splitContainerModelTables.Panel2.Controls.Add(this.dataGridViewTriangles);
-            this.splitContainerModelTables.Size = new System.Drawing.Size(340, 412);
+            this.splitContainerModelTables.Size = new System.Drawing.Size(323, 412);
             this.splitContainerModelTables.SplitterDistance = 200;
             this.splitContainerModelTables.TabIndex = 2;
             // 
@@ -9906,7 +9908,7 @@ namespace STROOP
             this.dataGridViewVertices.Name = "dataGridViewVertices";
             this.dataGridViewVertices.ReadOnly = true;
             this.dataGridViewVertices.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
-            this.dataGridViewVertices.Size = new System.Drawing.Size(329, 181);
+            this.dataGridViewVertices.Size = new System.Drawing.Size(312, 181);
             this.dataGridViewVertices.TabIndex = 1;
             // 
             // Index
@@ -9962,7 +9964,7 @@ namespace STROOP
             this.dataGridViewTriangles.Name = "dataGridViewTriangles";
             this.dataGridViewTriangles.ReadOnly = true;
             this.dataGridViewTriangles.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
-            this.dataGridViewTriangles.Size = new System.Drawing.Size(329, 189);
+            this.dataGridViewTriangles.Size = new System.Drawing.Size(312, 189);
             this.dataGridViewTriangles.TabIndex = 2;
             // 
             // Group
@@ -13858,12 +13860,43 @@ namespace STROOP
             this.splitContainerGfxRight.SplitterDistance = 350;
             this.splitContainerGfxRight.TabIndex = 0;
             // 
+            // splitContainerGfxMiddle
+            // 
+            this.splitContainerGfxMiddle.BackColor = System.Drawing.SystemColors.Control;
+            this.splitContainerGfxMiddle.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.splitContainerGfxMiddle.IsSplitterFixed = true;
+            this.splitContainerGfxMiddle.Location = new System.Drawing.Point(0, 0);
+            this.splitContainerGfxMiddle.Name = "splitContainerGfxMiddle";
+            this.splitContainerGfxMiddle.Orientation = System.Windows.Forms.Orientation.Horizontal;
+            // 
+            // splitContainerGfxMiddle.Panel1
+            // 
+            this.splitContainerGfxMiddle.Panel1.Controls.Add(this.buttonGfxDumpDisplayList);
+            this.splitContainerGfxMiddle.Panel1.Controls.Add(this.buttonGfxRefreshObject);
+            this.splitContainerGfxMiddle.Panel1.Controls.Add(this.buttonGfxRefresh);
+            // 
+            // splitContainerGfxMiddle.Panel2
+            // 
+            this.splitContainerGfxMiddle.Panel2.Controls.Add(this.watchVariablePanelGfx);
+            this.splitContainerGfxMiddle.Size = new System.Drawing.Size(350, 457);
+            this.splitContainerGfxMiddle.SplitterDistance = 40;
+            this.splitContainerGfxMiddle.TabIndex = 1;
+            // 
+            // buttonGfxRefresh
+            // 
+            this.buttonGfxRefresh.Location = new System.Drawing.Point(3, 3);
+            this.buttonGfxRefresh.Name = "buttonGfxRefresh";
+            this.buttonGfxRefresh.Size = new System.Drawing.Size(75, 23);
+            this.buttonGfxRefresh.TabIndex = 0;
+            this.buttonGfxRefresh.Text = "Refresh root";
+            this.buttonGfxRefresh.UseVisualStyleBackColor = true;
+            // 
             // watchVariablePanelGfx
             // 
             this.watchVariablePanelGfx.Dock = System.Windows.Forms.DockStyle.Fill;
             this.watchVariablePanelGfx.Location = new System.Drawing.Point(0, 0);
             this.watchVariablePanelGfx.Name = "watchVariablePanelGfx";
-            this.watchVariablePanelGfx.Size = new System.Drawing.Size(350, 403);
+            this.watchVariablePanelGfx.Size = new System.Drawing.Size(350, 413);
             this.watchVariablePanelGfx.TabIndex = 0;
             // 
             // richTextBoxGfx
@@ -14063,33 +14096,23 @@ namespace STROOP
             this.buttonShowLeftPane.UseVisualStyleBackColor = true;
             this.buttonShowLeftPane.Click += new System.EventHandler(this.buttonShowLeftPanel_Click);
             // 
-            // splitContainerGfxMiddle
+            // buttonGfxRefreshObject
             // 
-            this.splitContainerGfxMiddle.BackColor = System.Drawing.SystemColors.Control;
-            this.splitContainerGfxMiddle.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.splitContainerGfxMiddle.IsSplitterFixed = true;
-            this.splitContainerGfxMiddle.Location = new System.Drawing.Point(0, 0);
-            this.splitContainerGfxMiddle.Name = "splitContainerGfxMiddle";
-            this.splitContainerGfxMiddle.Orientation = System.Windows.Forms.Orientation.Horizontal;
+            this.buttonGfxRefreshObject.Location = new System.Drawing.Point(84, 3);
+            this.buttonGfxRefreshObject.Name = "buttonGfxRefreshObject";
+            this.buttonGfxRefreshObject.Size = new System.Drawing.Size(135, 23);
+            this.buttonGfxRefreshObject.TabIndex = 1;
+            this.buttonGfxRefreshObject.Text = "Refresh selected object";
+            this.buttonGfxRefreshObject.UseVisualStyleBackColor = true;
             // 
-            // splitContainerGfxMiddle.Panel1
+            // buttonGfxDumpDisplayList
             // 
-            this.splitContainerGfxMiddle.Panel1.Controls.Add(this.buttonGfxRefresh);
-            // 
-            // splitContainerGfxMiddle.Panel2
-            // 
-            this.splitContainerGfxMiddle.Panel2.Controls.Add(this.watchVariablePanelGfx);
-            this.splitContainerGfxMiddle.Size = new System.Drawing.Size(350, 457);
-            this.splitContainerGfxMiddle.TabIndex = 1;
-            // 
-            // buttonGfxRefresh
-            // 
-            this.buttonGfxRefresh.Location = new System.Drawing.Point(3, 3);
-            this.buttonGfxRefresh.Name = "buttonGfxRefresh";
-            this.buttonGfxRefresh.Size = new System.Drawing.Size(75, 23);
-            this.buttonGfxRefresh.TabIndex = 0;
-            this.buttonGfxRefresh.Text = "refresh";
-            this.buttonGfxRefresh.UseVisualStyleBackColor = true;
+            this.buttonGfxDumpDisplayList.Location = new System.Drawing.Point(225, 3);
+            this.buttonGfxDumpDisplayList.Name = "buttonGfxDumpDisplayList";
+            this.buttonGfxDumpDisplayList.Size = new System.Drawing.Size(104, 23);
+            this.buttonGfxDumpDisplayList.TabIndex = 2;
+            this.buttonGfxDumpDisplayList.Text = "Export display list";
+            this.buttonGfxDumpDisplayList.UseVisualStyleBackColor = true;
             // 
             // StroopMainForm
             // 
@@ -14525,12 +14548,12 @@ namespace STROOP
             this.splitContainerGfxRight.Panel2.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.splitContainerGfxRight)).EndInit();
             this.splitContainerGfxRight.ResumeLayout(false);
-            this.panelConnect.ResumeLayout(false);
-            this.panelConnect.PerformLayout();
             this.splitContainerGfxMiddle.Panel1.ResumeLayout(false);
             this.splitContainerGfxMiddle.Panel2.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.splitContainerGfxMiddle)).EndInit();
             this.splitContainerGfxMiddle.ResumeLayout(false);
+            this.panelConnect.ResumeLayout(false);
+            this.panelConnect.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -15585,6 +15608,8 @@ namespace STROOP
         private RichTextBox richTextBoxGfx;
         private SplitContainer splitContainerGfxMiddle;
         private Button buttonGfxRefresh;
+        private Button buttonGfxRefreshObject;
+        private Button buttonGfxDumpDisplayList;
     }
 }
 

--- a/STROOP/Forms/StroopMainForm.Designer.cs
+++ b/STROOP/Forms/StroopMainForm.Designer.cs
@@ -44,7 +44,7 @@ namespace STROOP
             this.comboBoxSortMethod = new System.Windows.Forms.ComboBox();
             this.trackBarObjSlotSize = new System.Windows.Forms.TrackBar();
             this.splitContainerMain = new System.Windows.Forms.SplitContainer();
-            this.Gfx = new System.Windows.Forms.TabControl();
+            this.tabControlMain = new System.Windows.Forms.TabControl();
             this.tabPageObjects = new System.Windows.Forms.TabPage();
             this.splitContainerObject = new System.Windows.Forms.SplitContainer();
             this.panelObj = new System.Windows.Forms.Panel();
@@ -542,6 +542,8 @@ namespace STROOP
             this.buttonCustomClearValues = new System.Windows.Forms.Button();
             this.buttonCustomShowValues = new System.Windows.Forms.Button();
             this.checkBoxCustomRecordValues = new System.Windows.Forms.CheckBox();
+            this.buttonClearVars = new System.Windows.Forms.Button();
+            this.buttonSaveVars = new System.Windows.Forms.Button();
             this.buttonOpenVars = new System.Windows.Forms.Button();
             this.groupBoxVarHeight = new System.Windows.Forms.GroupBox();
             this.betterTextboxVarHeightGetSet = new STROOP.BetterTextbox();
@@ -721,6 +723,16 @@ namespace STROOP
             this.label1 = new System.Windows.Forms.Label();
             this.textBoxModelAddress = new System.Windows.Forms.TextBox();
             this.glControlModelView = new OpenTK.GLControl();
+            this.tabPageGfx = new System.Windows.Forms.TabPage();
+            this.splitContainerGfxLeft = new System.Windows.Forms.SplitContainer();
+            this.treeViewGfx = new System.Windows.Forms.TreeView();
+            this.splitContainerGfxRight = new System.Windows.Forms.SplitContainer();
+            this.splitContainerGfxMiddle = new System.Windows.Forms.SplitContainer();
+            this.buttonGfxDumpDisplayList = new System.Windows.Forms.Button();
+            this.buttonGfxRefreshObject = new System.Windows.Forms.Button();
+            this.buttonGfxRefresh = new System.Windows.Forms.Button();
+            this.watchVariablePanelGfx = new STROOP.Controls.WatchVariablePanel();
+            this.richTextBoxGfx = new System.Windows.Forms.RichTextBox();
             this.tabPageDisassembly = new System.Windows.Forms.TabPage();
             this.textBoxDisAddress = new System.Windows.Forms.TextBox();
             this.buttonDisMore = new System.Windows.Forms.Button();
@@ -1057,14 +1069,6 @@ namespace STROOP
             this.labelMetric3Value = new System.Windows.Forms.Label();
             this.labelMetric5Value = new System.Windows.Forms.Label();
             this.labelMetric4Value = new System.Windows.Forms.Label();
-            this.tabPageGfx = new System.Windows.Forms.TabPage();
-            this.splitContainerGfxLeft = new System.Windows.Forms.SplitContainer();
-            this.treeViewGfx = new System.Windows.Forms.TreeView();
-            this.splitContainerGfxRight = new System.Windows.Forms.SplitContainer();
-            this.splitContainerGfxMiddle = new System.Windows.Forms.SplitContainer();
-            this.buttonGfxRefresh = new System.Windows.Forms.Button();
-            this.watchVariablePanelGfx = new STROOP.Controls.WatchVariablePanel();
-            this.richTextBoxGfx = new System.Windows.Forms.RichTextBox();
             this.labelVersionNumber = new System.Windows.Forms.Label();
             this.buttonDisconnect = new System.Windows.Forms.Button();
             this.panelConnect = new System.Windows.Forms.Panel();
@@ -1081,17 +1085,13 @@ namespace STROOP
             this.buttonShowRightPane = new System.Windows.Forms.Button();
             this.buttonShowLeftRightPane = new System.Windows.Forms.Button();
             this.buttonShowLeftPane = new System.Windows.Forms.Button();
-            this.buttonGfxRefreshObject = new System.Windows.Forms.Button();
-            this.buttonGfxDumpDisplayList = new System.Windows.Forms.Button();
-            this.buttonSaveVars = new System.Windows.Forms.Button();
-            this.buttonClearVars = new System.Windows.Forms.Button();
             this.groupBoxObjects.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.trackBarObjSlotSize)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainerMain)).BeginInit();
             this.splitContainerMain.Panel1.SuspendLayout();
             this.splitContainerMain.Panel2.SuspendLayout();
             this.splitContainerMain.SuspendLayout();
-            this.Gfx.SuspendLayout();
+            this.tabControlMain.SuspendLayout();
             this.tabPageObjects.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainerObject)).BeginInit();
             this.splitContainerObject.Panel1.SuspendLayout();
@@ -1367,6 +1367,19 @@ namespace STROOP
             this.splitContainerModelTables.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.dataGridViewVertices)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.dataGridViewTriangles)).BeginInit();
+            this.tabPageGfx.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.splitContainerGfxLeft)).BeginInit();
+            this.splitContainerGfxLeft.Panel1.SuspendLayout();
+            this.splitContainerGfxLeft.Panel2.SuspendLayout();
+            this.splitContainerGfxLeft.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.splitContainerGfxRight)).BeginInit();
+            this.splitContainerGfxRight.Panel1.SuspendLayout();
+            this.splitContainerGfxRight.Panel2.SuspendLayout();
+            this.splitContainerGfxRight.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.splitContainerGfxMiddle)).BeginInit();
+            this.splitContainerGfxMiddle.Panel1.SuspendLayout();
+            this.splitContainerGfxMiddle.Panel2.SuspendLayout();
+            this.splitContainerGfxMiddle.SuspendLayout();
             this.tabPageDisassembly.SuspendLayout();
             this.tabPageDecompiler.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainerDecompiler)).BeginInit();
@@ -1414,19 +1427,6 @@ namespace STROOP
             this.groupBoxObjAtHOLP.SuspendLayout();
             this.groupBoxGoto.SuspendLayout();
             this.groupBoxRecording.SuspendLayout();
-            this.tabPageGfx.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.splitContainerGfxLeft)).BeginInit();
-            this.splitContainerGfxLeft.Panel1.SuspendLayout();
-            this.splitContainerGfxLeft.Panel2.SuspendLayout();
-            this.splitContainerGfxLeft.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.splitContainerGfxRight)).BeginInit();
-            this.splitContainerGfxRight.Panel1.SuspendLayout();
-            this.splitContainerGfxRight.Panel2.SuspendLayout();
-            this.splitContainerGfxRight.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.splitContainerGfxMiddle)).BeginInit();
-            this.splitContainerGfxMiddle.Panel1.SuspendLayout();
-            this.splitContainerGfxMiddle.Panel2.SuspendLayout();
-            this.splitContainerGfxMiddle.SuspendLayout();
             this.panelConnect.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -1457,7 +1457,7 @@ namespace STROOP
             this.groupBoxObjects.Margin = new System.Windows.Forms.Padding(2);
             this.groupBoxObjects.Name = "groupBoxObjects";
             this.groupBoxObjects.Padding = new System.Windows.Forms.Padding(2);
-            this.groupBoxObjects.Size = new System.Drawing.Size(923, 376);
+            this.groupBoxObjects.Size = new System.Drawing.Size(923, 377);
             this.groupBoxObjects.TabIndex = 2;
             this.groupBoxObjects.TabStop = false;
             this.groupBoxObjects.Text = "Objects";
@@ -1522,7 +1522,7 @@ namespace STROOP
             this.WatchVariablePanelObjects.Location = new System.Drawing.Point(4, 45);
             this.WatchVariablePanelObjects.Margin = new System.Windows.Forms.Padding(2);
             this.WatchVariablePanelObjects.Name = "WatchVariablePanelObjects";
-            this.WatchVariablePanelObjects.Size = new System.Drawing.Size(915, 154);
+            this.WatchVariablePanelObjects.Size = new System.Drawing.Size(915, 155);
             this.WatchVariablePanelObjects.TabIndex = 0;
             this.WatchVariablePanelObjects.Resize += new System.EventHandler(this.WatchVariablePanelObjects_Resize);
             // 
@@ -1561,7 +1561,7 @@ namespace STROOP
             // 
             // splitContainerMain.Panel1
             // 
-            this.splitContainerMain.Panel1.Controls.Add(this.Gfx);
+            this.splitContainerMain.Panel1.Controls.Add(this.tabControlMain);
             this.splitContainerMain.Panel1MinSize = 0;
             // 
             // splitContainerMain.Panel2
@@ -1573,46 +1573,46 @@ namespace STROOP
             this.splitContainerMain.SplitterWidth = 3;
             this.splitContainerMain.TabIndex = 4;
             // 
-            // Gfx
+            // tabControlMain
             // 
-            this.Gfx.AllowDrop = true;
-            this.Gfx.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            this.tabControlMain.AllowDrop = true;
+            this.tabControlMain.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.Gfx.Controls.Add(this.tabPageObjects);
-            this.Gfx.Controls.Add(this.tabPageMario);
-            this.Gfx.Controls.Add(this.tabPageHud);
-            this.Gfx.Controls.Add(this.tabPageCamera);
-            this.Gfx.Controls.Add(this.tabPageTriangles);
-            this.Gfx.Controls.Add(this.tabPageWater);
-            this.Gfx.Controls.Add(this.tabPageActions);
-            this.Gfx.Controls.Add(this.tabPageInput);
-            this.Gfx.Controls.Add(this.tabPageFile);
-            this.Gfx.Controls.Add(this.tabPageMisc);
-            this.Gfx.Controls.Add(this.tabPageCustom);
-            this.Gfx.Controls.Add(this.tabPageDebug);
-            this.Gfx.Controls.Add(this.tabPageMap);
-            this.Gfx.Controls.Add(this.tabPagePu);
-            this.Gfx.Controls.Add(this.tabPageArea);
-            this.Gfx.Controls.Add(this.tabPageModel);
-            this.Gfx.Controls.Add(this.tabPageGfx);
-            this.Gfx.Controls.Add(this.tabPageDisassembly);
-            this.Gfx.Controls.Add(this.tabPageDecompiler);
-            this.Gfx.Controls.Add(this.tabPageScripts);
-            this.Gfx.Controls.Add(this.tabPageHacks);
-            this.Gfx.Controls.Add(this.tabPageCamHack);
-            this.Gfx.Controls.Add(this.tabPageQuarterFrame);
-            this.Gfx.Controls.Add(this.tabPageVarHack);
-            this.Gfx.Controls.Add(this.tabPageOptions);
-            this.Gfx.Controls.Add(this.tabPageTesting);
-            this.Gfx.Cursor = System.Windows.Forms.Cursors.Default;
-            this.Gfx.HotTrack = true;
-            this.Gfx.Location = new System.Drawing.Point(2, 2);
-            this.Gfx.Margin = new System.Windows.Forms.Padding(2);
-            this.Gfx.Name = "Gfx";
-            this.Gfx.SelectedIndex = 0;
-            this.Gfx.Size = new System.Drawing.Size(923, 489);
-            this.Gfx.TabIndex = 3;
+            this.tabControlMain.Controls.Add(this.tabPageObjects);
+            this.tabControlMain.Controls.Add(this.tabPageMario);
+            this.tabControlMain.Controls.Add(this.tabPageHud);
+            this.tabControlMain.Controls.Add(this.tabPageCamera);
+            this.tabControlMain.Controls.Add(this.tabPageTriangles);
+            this.tabControlMain.Controls.Add(this.tabPageWater);
+            this.tabControlMain.Controls.Add(this.tabPageActions);
+            this.tabControlMain.Controls.Add(this.tabPageInput);
+            this.tabControlMain.Controls.Add(this.tabPageFile);
+            this.tabControlMain.Controls.Add(this.tabPageMisc);
+            this.tabControlMain.Controls.Add(this.tabPageCustom);
+            this.tabControlMain.Controls.Add(this.tabPageDebug);
+            this.tabControlMain.Controls.Add(this.tabPageMap);
+            this.tabControlMain.Controls.Add(this.tabPagePu);
+            this.tabControlMain.Controls.Add(this.tabPageArea);
+            this.tabControlMain.Controls.Add(this.tabPageModel);
+            this.tabControlMain.Controls.Add(this.tabPageGfx);
+            this.tabControlMain.Controls.Add(this.tabPageDisassembly);
+            this.tabControlMain.Controls.Add(this.tabPageDecompiler);
+            this.tabControlMain.Controls.Add(this.tabPageScripts);
+            this.tabControlMain.Controls.Add(this.tabPageHacks);
+            this.tabControlMain.Controls.Add(this.tabPageCamHack);
+            this.tabControlMain.Controls.Add(this.tabPageQuarterFrame);
+            this.tabControlMain.Controls.Add(this.tabPageVarHack);
+            this.tabControlMain.Controls.Add(this.tabPageOptions);
+            this.tabControlMain.Controls.Add(this.tabPageTesting);
+            this.tabControlMain.Cursor = System.Windows.Forms.Cursors.Default;
+            this.tabControlMain.HotTrack = true;
+            this.tabControlMain.Location = new System.Drawing.Point(2, 2);
+            this.tabControlMain.Margin = new System.Windows.Forms.Padding(2);
+            this.tabControlMain.Name = "tabControlMain";
+            this.tabControlMain.SelectedIndex = 0;
+            this.tabControlMain.Size = new System.Drawing.Size(923, 489);
+            this.tabControlMain.TabIndex = 3;
             // 
             // tabPageObjects
             // 
@@ -4715,7 +4715,7 @@ namespace STROOP
             this.tableLayoutPanelFile.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 20F));
             this.tableLayoutPanelFile.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 20F));
             this.tableLayoutPanelFile.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 20F));
-            this.tableLayoutPanelFile.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 220F));
+            this.tableLayoutPanelFile.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 221F));
             this.tableLayoutPanelFile.Controls.Add(this.textBoxTableRow15Col10, 10, 14);
             this.tableLayoutPanelFile.Controls.Add(this.textBoxTableRow14Col10, 10, 13);
             this.tableLayoutPanelFile.Controls.Add(this.textBoxTableRow13Col10, 10, 12);
@@ -7974,6 +7974,24 @@ namespace STROOP
             this.checkBoxCustomRecordValues.Text = "Record Values";
             this.checkBoxCustomRecordValues.UseVisualStyleBackColor = true;
             // 
+            // buttonClearVars
+            // 
+            this.buttonClearVars.Location = new System.Drawing.Point(131, 6);
+            this.buttonClearVars.Name = "buttonClearVars";
+            this.buttonClearVars.Size = new System.Drawing.Size(58, 38);
+            this.buttonClearVars.TabIndex = 4;
+            this.buttonClearVars.Text = "Clear\r\nVars";
+            this.buttonClearVars.UseVisualStyleBackColor = true;
+            // 
+            // buttonSaveVars
+            // 
+            this.buttonSaveVars.Location = new System.Drawing.Point(71, 6);
+            this.buttonSaveVars.Name = "buttonSaveVars";
+            this.buttonSaveVars.Size = new System.Drawing.Size(58, 38);
+            this.buttonSaveVars.TabIndex = 4;
+            this.buttonSaveVars.Text = "Save\r\nVars";
+            this.buttonSaveVars.UseVisualStyleBackColor = true;
+            // 
             // buttonOpenVars
             // 
             this.buttonOpenVars.Location = new System.Drawing.Point(11, 6);
@@ -8913,7 +8931,7 @@ namespace STROOP
             this.glControlMap.Location = new System.Drawing.Point(4, 3);
             this.glControlMap.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.glControlMap.Name = "glControlMap";
-            this.glControlMap.Size = new System.Drawing.Size(699, 454);
+            this.glControlMap.Size = new System.Drawing.Size(702, 454);
             this.glControlMap.TabIndex = 0;
             this.glControlMap.VSync = false;
             this.glControlMap.Load += new System.EventHandler(this.glControlMap_Load);
@@ -9880,7 +9898,7 @@ namespace STROOP
             // 
             this.splitContainerModelTables.Panel2.Controls.Add(this.labelModelTriangles);
             this.splitContainerModelTables.Panel2.Controls.Add(this.dataGridViewTriangles);
-            this.splitContainerModelTables.Size = new System.Drawing.Size(374, 412);
+            this.splitContainerModelTables.Size = new System.Drawing.Size(357, 412);
             this.splitContainerModelTables.SplitterDistance = 200;
             this.splitContainerModelTables.TabIndex = 2;
             // 
@@ -9912,7 +9930,7 @@ namespace STROOP
             this.dataGridViewVertices.Name = "dataGridViewVertices";
             this.dataGridViewVertices.ReadOnly = true;
             this.dataGridViewVertices.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
-            this.dataGridViewVertices.Size = new System.Drawing.Size(363, 181);
+            this.dataGridViewVertices.Size = new System.Drawing.Size(346, 181);
             this.dataGridViewVertices.TabIndex = 1;
             // 
             // Index
@@ -9968,8 +9986,7 @@ namespace STROOP
             this.dataGridViewTriangles.Name = "dataGridViewTriangles";
             this.dataGridViewTriangles.ReadOnly = true;
             this.dataGridViewTriangles.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
-            this.dataGridViewTriangles.Size = new System.Drawing.Size(312, 189);
-            this.dataGridViewTriangles.Size = new System.Drawing.Size(363, 189);
+            this.dataGridViewTriangles.Size = new System.Drawing.Size(346, 189);
             this.dataGridViewTriangles.TabIndex = 2;
             // 
             // Group
@@ -10031,6 +10048,127 @@ namespace STROOP
             this.glControlModelView.TabIndex = 0;
             this.glControlModelView.VSync = false;
             this.glControlModelView.Load += new System.EventHandler(this.glControlModelView_Load);
+            // 
+            // tabPageGfx
+            // 
+            this.tabPageGfx.Controls.Add(this.splitContainerGfxLeft);
+            this.tabPageGfx.Location = new System.Drawing.Point(4, 22);
+            this.tabPageGfx.Name = "tabPageGfx";
+            this.tabPageGfx.Padding = new System.Windows.Forms.Padding(3);
+            this.tabPageGfx.Size = new System.Drawing.Size(915, 463);
+            this.tabPageGfx.TabIndex = 25;
+            this.tabPageGfx.Text = "Gfx";
+            this.tabPageGfx.UseVisualStyleBackColor = true;
+            // 
+            // splitContainerGfxLeft
+            // 
+            this.splitContainerGfxLeft.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.splitContainerGfxLeft.Location = new System.Drawing.Point(3, 3);
+            this.splitContainerGfxLeft.Name = "splitContainerGfxLeft";
+            // 
+            // splitContainerGfxLeft.Panel1
+            // 
+            this.splitContainerGfxLeft.Panel1.Controls.Add(this.treeViewGfx);
+            // 
+            // splitContainerGfxLeft.Panel2
+            // 
+            this.splitContainerGfxLeft.Panel2.Controls.Add(this.splitContainerGfxRight);
+            this.splitContainerGfxLeft.Size = new System.Drawing.Size(909, 457);
+            this.splitContainerGfxLeft.SplitterDistance = 300;
+            this.splitContainerGfxLeft.TabIndex = 0;
+            // 
+            // treeViewGfx
+            // 
+            this.treeViewGfx.BackColor = System.Drawing.SystemColors.Control;
+            this.treeViewGfx.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.treeViewGfx.Location = new System.Drawing.Point(0, 0);
+            this.treeViewGfx.Name = "treeViewGfx";
+            this.treeViewGfx.Size = new System.Drawing.Size(300, 457);
+            this.treeViewGfx.TabIndex = 0;
+            // 
+            // splitContainerGfxRight
+            // 
+            this.splitContainerGfxRight.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.splitContainerGfxRight.Location = new System.Drawing.Point(0, 0);
+            this.splitContainerGfxRight.Name = "splitContainerGfxRight";
+            // 
+            // splitContainerGfxRight.Panel1
+            // 
+            this.splitContainerGfxRight.Panel1.Controls.Add(this.splitContainerGfxMiddle);
+            // 
+            // splitContainerGfxRight.Panel2
+            // 
+            this.splitContainerGfxRight.Panel2.Controls.Add(this.richTextBoxGfx);
+            this.splitContainerGfxRight.Size = new System.Drawing.Size(605, 457);
+            this.splitContainerGfxRight.SplitterDistance = 323;
+            this.splitContainerGfxRight.TabIndex = 0;
+            // 
+            // splitContainerGfxMiddle
+            // 
+            this.splitContainerGfxMiddle.BackColor = System.Drawing.SystemColors.Control;
+            this.splitContainerGfxMiddle.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.splitContainerGfxMiddle.IsSplitterFixed = true;
+            this.splitContainerGfxMiddle.Location = new System.Drawing.Point(0, 0);
+            this.splitContainerGfxMiddle.Name = "splitContainerGfxMiddle";
+            this.splitContainerGfxMiddle.Orientation = System.Windows.Forms.Orientation.Horizontal;
+            // 
+            // splitContainerGfxMiddle.Panel1
+            // 
+            this.splitContainerGfxMiddle.Panel1.Controls.Add(this.buttonGfxDumpDisplayList);
+            this.splitContainerGfxMiddle.Panel1.Controls.Add(this.buttonGfxRefreshObject);
+            this.splitContainerGfxMiddle.Panel1.Controls.Add(this.buttonGfxRefresh);
+            // 
+            // splitContainerGfxMiddle.Panel2
+            // 
+            this.splitContainerGfxMiddle.Panel2.Controls.Add(this.watchVariablePanelGfx);
+            this.splitContainerGfxMiddle.Size = new System.Drawing.Size(323, 457);
+            this.splitContainerGfxMiddle.SplitterDistance = 60;
+            this.splitContainerGfxMiddle.TabIndex = 1;
+            // 
+            // buttonGfxDumpDisplayList
+            // 
+            this.buttonGfxDumpDisplayList.Location = new System.Drawing.Point(3, 31);
+            this.buttonGfxDumpDisplayList.Name = "buttonGfxDumpDisplayList";
+            this.buttonGfxDumpDisplayList.Size = new System.Drawing.Size(104, 23);
+            this.buttonGfxDumpDisplayList.TabIndex = 2;
+            this.buttonGfxDumpDisplayList.Text = "Export display list";
+            this.buttonGfxDumpDisplayList.UseVisualStyleBackColor = true;
+            // 
+            // buttonGfxRefreshObject
+            // 
+            this.buttonGfxRefreshObject.Location = new System.Drawing.Point(94, 3);
+            this.buttonGfxRefreshObject.Name = "buttonGfxRefreshObject";
+            this.buttonGfxRefreshObject.Size = new System.Drawing.Size(147, 23);
+            this.buttonGfxRefreshObject.TabIndex = 1;
+            this.buttonGfxRefreshObject.Text = "Build from selected objects";
+            this.buttonGfxRefreshObject.UseVisualStyleBackColor = true;
+            // 
+            // buttonGfxRefresh
+            // 
+            this.buttonGfxRefresh.Location = new System.Drawing.Point(3, 3);
+            this.buttonGfxRefresh.Name = "buttonGfxRefresh";
+            this.buttonGfxRefresh.Size = new System.Drawing.Size(85, 23);
+            this.buttonGfxRefresh.TabIndex = 0;
+            this.buttonGfxRefresh.Text = "Build from root";
+            this.buttonGfxRefresh.UseVisualStyleBackColor = true;
+            // 
+            // watchVariablePanelGfx
+            // 
+            this.watchVariablePanelGfx.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.watchVariablePanelGfx.Location = new System.Drawing.Point(0, 0);
+            this.watchVariablePanelGfx.Name = "watchVariablePanelGfx";
+            this.watchVariablePanelGfx.Size = new System.Drawing.Size(323, 393);
+            this.watchVariablePanelGfx.TabIndex = 0;
+            // 
+            // richTextBoxGfx
+            // 
+            this.richTextBoxGfx.BackColor = System.Drawing.SystemColors.Control;
+            this.richTextBoxGfx.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.richTextBoxGfx.Location = new System.Drawing.Point(0, 0);
+            this.richTextBoxGfx.Name = "richTextBoxGfx";
+            this.richTextBoxGfx.Size = new System.Drawing.Size(278, 457);
+            this.richTextBoxGfx.TabIndex = 0;
+            this.richTextBoxGfx.Text = "";
             // 
             // tabPageDisassembly
             // 
@@ -13811,109 +13949,6 @@ namespace STROOP
             this.labelMetric4Value.Text = "Value";
             this.labelMetric4Value.TextAlign = System.Drawing.ContentAlignment.TopCenter;
             // 
-            // tabPageGfx
-            // 
-            this.tabPageGfx.Controls.Add(this.splitContainerGfxLeft);
-            this.tabPageGfx.Location = new System.Drawing.Point(4, 22);
-            this.tabPageGfx.Name = "tabPageGfx";
-            this.tabPageGfx.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPageGfx.Size = new System.Drawing.Size(915, 463);
-            this.tabPageGfx.TabIndex = 25;
-            this.tabPageGfx.Text = "Gfx";
-            this.tabPageGfx.UseVisualStyleBackColor = true;
-            // 
-            // splitContainerGfxLeft
-            // 
-            this.splitContainerGfxLeft.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.splitContainerGfxLeft.Location = new System.Drawing.Point(3, 3);
-            this.splitContainerGfxLeft.Name = "splitContainerGfxLeft";
-            // 
-            // splitContainerGfxLeft.Panel1
-            // 
-            this.splitContainerGfxLeft.Panel1.Controls.Add(this.treeViewGfx);
-            // 
-            // splitContainerGfxLeft.Panel2
-            // 
-            this.splitContainerGfxLeft.Panel2.Controls.Add(this.splitContainerGfxRight);
-            this.splitContainerGfxLeft.Size = new System.Drawing.Size(909, 457);
-            this.splitContainerGfxLeft.SplitterDistance = 300;
-            this.splitContainerGfxLeft.TabIndex = 0;
-            // 
-            // treeViewGfx
-            // 
-            this.treeViewGfx.BackColor = System.Drawing.SystemColors.Control;
-            this.treeViewGfx.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.treeViewGfx.Location = new System.Drawing.Point(0, 0);
-            this.treeViewGfx.Name = "treeViewGfx";
-            this.treeViewGfx.Size = new System.Drawing.Size(300, 457);
-            this.treeViewGfx.TabIndex = 0;
-            // 
-            // splitContainerGfxRight
-            // 
-            this.splitContainerGfxRight.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.splitContainerGfxRight.Location = new System.Drawing.Point(0, 0);
-            this.splitContainerGfxRight.Name = "splitContainerGfxRight";
-            // 
-            // splitContainerGfxRight.Panel1
-            // 
-            this.splitContainerGfxRight.Panel1.Controls.Add(this.splitContainerGfxMiddle);
-            // 
-            // splitContainerGfxRight.Panel2
-            // 
-            this.splitContainerGfxRight.Panel2.Controls.Add(this.richTextBoxGfx);
-            this.splitContainerGfxRight.Size = new System.Drawing.Size(605, 457);
-            this.splitContainerGfxRight.SplitterDistance = 323;
-            this.splitContainerGfxRight.TabIndex = 0;
-            // 
-            // splitContainerGfxMiddle
-            // 
-            this.splitContainerGfxMiddle.BackColor = System.Drawing.SystemColors.Control;
-            this.splitContainerGfxMiddle.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.splitContainerGfxMiddle.IsSplitterFixed = true;
-            this.splitContainerGfxMiddle.Location = new System.Drawing.Point(0, 0);
-            this.splitContainerGfxMiddle.Name = "splitContainerGfxMiddle";
-            this.splitContainerGfxMiddle.Orientation = System.Windows.Forms.Orientation.Horizontal;
-            // 
-            // splitContainerGfxMiddle.Panel1
-            // 
-            this.splitContainerGfxMiddle.Panel1.Controls.Add(this.buttonGfxDumpDisplayList);
-            this.splitContainerGfxMiddle.Panel1.Controls.Add(this.buttonGfxRefreshObject);
-            this.splitContainerGfxMiddle.Panel1.Controls.Add(this.buttonGfxRefresh);
-            // 
-            // splitContainerGfxMiddle.Panel2
-            // 
-            this.splitContainerGfxMiddle.Panel2.Controls.Add(this.watchVariablePanelGfx);
-            this.splitContainerGfxMiddle.Size = new System.Drawing.Size(323, 457);
-            this.splitContainerGfxMiddle.SplitterDistance = 60;
-            this.splitContainerGfxMiddle.TabIndex = 1;
-            // 
-            // buttonGfxRefresh
-            // 
-            this.buttonGfxRefresh.Location = new System.Drawing.Point(3, 3);
-            this.buttonGfxRefresh.Name = "buttonGfxRefresh";
-            this.buttonGfxRefresh.Size = new System.Drawing.Size(85, 23);
-            this.buttonGfxRefresh.TabIndex = 0;
-            this.buttonGfxRefresh.Text = "Build from root";
-            this.buttonGfxRefresh.UseVisualStyleBackColor = true;
-            // 
-            // watchVariablePanelGfx
-            // 
-            this.watchVariablePanelGfx.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.watchVariablePanelGfx.Location = new System.Drawing.Point(0, 0);
-            this.watchVariablePanelGfx.Name = "watchVariablePanelGfx";
-            this.watchVariablePanelGfx.Size = new System.Drawing.Size(323, 393);
-            this.watchVariablePanelGfx.TabIndex = 0;
-            // 
-            // richTextBoxGfx
-            // 
-            this.richTextBoxGfx.BackColor = System.Drawing.SystemColors.Control;
-            this.richTextBoxGfx.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.richTextBoxGfx.Location = new System.Drawing.Point(0, 0);
-            this.richTextBoxGfx.Name = "richTextBoxGfx";
-            this.richTextBoxGfx.Size = new System.Drawing.Size(278, 457);
-            this.richTextBoxGfx.TabIndex = 0;
-            this.richTextBoxGfx.Text = "";
-            // 
             // labelVersionNumber
             // 
             this.labelVersionNumber.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
@@ -14101,42 +14136,6 @@ namespace STROOP
             this.buttonShowLeftPane.UseVisualStyleBackColor = true;
             this.buttonShowLeftPane.Click += new System.EventHandler(this.buttonShowLeftPanel_Click);
             // 
-            // buttonGfxRefreshObject
-            // 
-            this.buttonGfxRefreshObject.Location = new System.Drawing.Point(94, 3);
-            this.buttonGfxRefreshObject.Name = "buttonGfxRefreshObject";
-            this.buttonGfxRefreshObject.Size = new System.Drawing.Size(147, 23);
-            this.buttonGfxRefreshObject.TabIndex = 1;
-            this.buttonGfxRefreshObject.Text = "Build from selected objects";
-            this.buttonGfxRefreshObject.UseVisualStyleBackColor = true;
-            // 
-            // buttonGfxDumpDisplayList
-            // 
-            this.buttonGfxDumpDisplayList.Location = new System.Drawing.Point(3, 31);
-            this.buttonGfxDumpDisplayList.Name = "buttonGfxDumpDisplayList";
-            this.buttonGfxDumpDisplayList.Size = new System.Drawing.Size(104, 23);
-            this.buttonGfxDumpDisplayList.TabIndex = 2;
-            this.buttonGfxDumpDisplayList.Text = "Export display list";
-            this.buttonGfxDumpDisplayList.UseVisualStyleBackColor = true;
-            //
-            // buttonSaveVars
-            // 
-            this.buttonSaveVars.Location = new System.Drawing.Point(71, 6);
-            this.buttonSaveVars.Name = "buttonSaveVars";
-            this.buttonSaveVars.Size = new System.Drawing.Size(58, 38);
-            this.buttonSaveVars.TabIndex = 4;
-            this.buttonSaveVars.Text = "Save\r\nVars";
-            this.buttonSaveVars.UseVisualStyleBackColor = true;
-            // 
-            // buttonClearVars
-            // 
-            this.buttonClearVars.Location = new System.Drawing.Point(131, 6);
-            this.buttonClearVars.Name = "buttonClearVars";
-            this.buttonClearVars.Size = new System.Drawing.Size(58, 38);
-            this.buttonClearVars.TabIndex = 4;
-            this.buttonClearVars.Text = "Clear\r\nVars";
-            this.buttonClearVars.UseVisualStyleBackColor = true;
-            // 
             // StroopMainForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -14169,7 +14168,7 @@ namespace STROOP
             this.splitContainerMain.Panel2.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.splitContainerMain)).EndInit();
             this.splitContainerMain.ResumeLayout(false);
-            this.Gfx.ResumeLayout(false);
+            this.tabControlMain.ResumeLayout(false);
             this.tabPageObjects.ResumeLayout(false);
             this.splitContainerObject.Panel1.ResumeLayout(false);
             this.splitContainerObject.Panel1.PerformLayout();
@@ -14487,6 +14486,19 @@ namespace STROOP
             this.splitContainerModelTables.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.dataGridViewVertices)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.dataGridViewTriangles)).EndInit();
+            this.tabPageGfx.ResumeLayout(false);
+            this.splitContainerGfxLeft.Panel1.ResumeLayout(false);
+            this.splitContainerGfxLeft.Panel2.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.splitContainerGfxLeft)).EndInit();
+            this.splitContainerGfxLeft.ResumeLayout(false);
+            this.splitContainerGfxRight.Panel1.ResumeLayout(false);
+            this.splitContainerGfxRight.Panel2.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.splitContainerGfxRight)).EndInit();
+            this.splitContainerGfxRight.ResumeLayout(false);
+            this.splitContainerGfxMiddle.Panel1.ResumeLayout(false);
+            this.splitContainerGfxMiddle.Panel2.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.splitContainerGfxMiddle)).EndInit();
+            this.splitContainerGfxMiddle.ResumeLayout(false);
             this.tabPageDisassembly.ResumeLayout(false);
             this.tabPageDisassembly.PerformLayout();
             this.tabPageDecompiler.ResumeLayout(false);
@@ -14562,19 +14574,6 @@ namespace STROOP
             this.groupBoxGoto.PerformLayout();
             this.groupBoxRecording.ResumeLayout(false);
             this.groupBoxRecording.PerformLayout();
-            this.tabPageGfx.ResumeLayout(false);
-            this.splitContainerGfxLeft.Panel1.ResumeLayout(false);
-            this.splitContainerGfxLeft.Panel2.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)(this.splitContainerGfxLeft)).EndInit();
-            this.splitContainerGfxLeft.ResumeLayout(false);
-            this.splitContainerGfxRight.Panel1.ResumeLayout(false);
-            this.splitContainerGfxRight.Panel2.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)(this.splitContainerGfxRight)).EndInit();
-            this.splitContainerGfxRight.ResumeLayout(false);
-            this.splitContainerGfxMiddle.Panel1.ResumeLayout(false);
-            this.splitContainerGfxMiddle.Panel2.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)(this.splitContainerGfxMiddle)).EndInit();
-            this.splitContainerGfxMiddle.ResumeLayout(false);
             this.panelConnect.ResumeLayout(false);
             this.panelConnect.PerformLayout();
             this.ResumeLayout(false);
@@ -14590,7 +14589,7 @@ namespace STROOP
         private WatchVariablePanel WatchVariablePanelObjects;
         private System.Windows.Forms.SplitContainer splitContainerMain;
         private System.Windows.Forms.CheckBox checkBoxObjLockLabels;
-        private System.Windows.Forms.TabControl Gfx;
+        private System.Windows.Forms.TabControl tabControlMain;
         private System.Windows.Forms.TabPage tabPageObjects;
         private System.Windows.Forms.Label labelObjSlotIndValue;
         private System.Windows.Forms.Label labelObjSlotPosValue;

--- a/STROOP/Forms/StroopMainForm.Designer.cs
+++ b/STROOP/Forms/StroopMainForm.Designer.cs
@@ -44,8 +44,9 @@ namespace STROOP
             this.comboBoxSortMethod = new System.Windows.Forms.ComboBox();
             this.trackBarObjSlotSize = new System.Windows.Forms.TrackBar();
             this.splitContainerMain = new System.Windows.Forms.SplitContainer();
-            this.tabControlMain = new System.Windows.Forms.TabControl();
+            this.Gfx = new System.Windows.Forms.TabControl();
             this.tabPageObjects = new System.Windows.Forms.TabPage();
+            this.watchVariablePanel1 = new STROOP.Controls.WatchVariablePanel();
             this.splitContainerObject = new System.Windows.Forms.SplitContainer();
             this.panelObj = new System.Windows.Forms.Panel();
             this.buttonObjRelease = new STROOP.BinaryButton();
@@ -909,6 +910,12 @@ namespace STROOP
             this.checkBoxUseRomHack = new System.Windows.Forms.CheckBox();
             this.checkBoxStartSlotIndexOne = new System.Windows.Forms.CheckBox();
             this.tabPageTesting = new System.Windows.Forms.TabPage();
+            this.groupBoxTriRooms = new System.Windows.Forms.GroupBox();
+            this.textBoxTriRoomsToValue = new STROOP.BetterTextbox();
+            this.textBoxTriRoomsFromValue = new STROOP.BetterTextbox();
+            this.buttonTriRoomsConvert = new System.Windows.Forms.Button();
+            this.labelTriRoomsToLabel = new System.Windows.Forms.Label();
+            this.labelTriRoomsFromLabel = new System.Windows.Forms.Label();
             this.groupBoxScuttlebugStuff = new System.Windows.Forms.GroupBox();
             this.buttonScuttlebugStuffGetTris = new STROOP.BinaryButton();
             this.radioButtonScuttlebugStuffHMCRedCoins = new System.Windows.Forms.RadioButton();
@@ -1051,6 +1058,12 @@ namespace STROOP
             this.labelMetric3Value = new System.Windows.Forms.Label();
             this.labelMetric5Value = new System.Windows.Forms.Label();
             this.labelMetric4Value = new System.Windows.Forms.Label();
+            this.tabPageGfx = new System.Windows.Forms.TabPage();
+            this.splitContainerGfxLeft = new System.Windows.Forms.SplitContainer();
+            this.treeViewGfx = new System.Windows.Forms.TreeView();
+            this.splitContainerGfxRight = new System.Windows.Forms.SplitContainer();
+            this.watchVariablePanelGfx = new STROOP.Controls.WatchVariablePanel();
+            this.richTextBoxGfx = new System.Windows.Forms.RichTextBox();
             this.labelVersionNumber = new System.Windows.Forms.Label();
             this.buttonDisconnect = new System.Windows.Forms.Button();
             this.panelConnect = new System.Windows.Forms.Panel();
@@ -1067,19 +1080,15 @@ namespace STROOP
             this.buttonShowRightPane = new System.Windows.Forms.Button();
             this.buttonShowLeftRightPane = new System.Windows.Forms.Button();
             this.buttonShowLeftPane = new System.Windows.Forms.Button();
-            this.groupBoxTriRooms = new System.Windows.Forms.GroupBox();
-            this.textBoxTriRoomsToValue = new STROOP.BetterTextbox();
-            this.textBoxTriRoomsFromValue = new STROOP.BetterTextbox();
-            this.buttonTriRoomsConvert = new System.Windows.Forms.Button();
-            this.labelTriRoomsToLabel = new System.Windows.Forms.Label();
-            this.labelTriRoomsFromLabel = new System.Windows.Forms.Label();
+            this.splitContainerGfxMiddle = new System.Windows.Forms.SplitContainer();
+            this.buttonGfxRefresh = new System.Windows.Forms.Button();
             this.groupBoxObjects.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.trackBarObjSlotSize)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainerMain)).BeginInit();
             this.splitContainerMain.Panel1.SuspendLayout();
             this.splitContainerMain.Panel2.SuspendLayout();
             this.splitContainerMain.SuspendLayout();
-            this.tabControlMain.SuspendLayout();
+            this.Gfx.SuspendLayout();
             this.tabPageObjects.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainerObject)).BeginInit();
             this.splitContainerObject.Panel1.SuspendLayout();
@@ -1392,6 +1401,7 @@ namespace STROOP
             this.groupBoxGotoRetrieveOffsets.SuspendLayout();
             this.groupBoxShowOverlay.SuspendLayout();
             this.tabPageTesting.SuspendLayout();
+            this.groupBoxTriRooms.SuspendLayout();
             this.groupBoxScuttlebugStuff.SuspendLayout();
             this.groupBoxSchedule.SuspendLayout();
             this.groupBoxStateTransfer.SuspendLayout();
@@ -1401,8 +1411,20 @@ namespace STROOP
             this.groupBoxObjAtHOLP.SuspendLayout();
             this.groupBoxGoto.SuspendLayout();
             this.groupBoxRecording.SuspendLayout();
+            this.tabPageGfx.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.splitContainerGfxLeft)).BeginInit();
+            this.splitContainerGfxLeft.Panel1.SuspendLayout();
+            this.splitContainerGfxLeft.Panel2.SuspendLayout();
+            this.splitContainerGfxLeft.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.splitContainerGfxRight)).BeginInit();
+            this.splitContainerGfxRight.Panel1.SuspendLayout();
+            this.splitContainerGfxRight.Panel2.SuspendLayout();
+            this.splitContainerGfxRight.SuspendLayout();
             this.panelConnect.SuspendLayout();
-            this.groupBoxTriRooms.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.splitContainerGfxMiddle)).BeginInit();
+            this.splitContainerGfxMiddle.Panel1.SuspendLayout();
+            this.splitContainerGfxMiddle.Panel2.SuspendLayout();
+            this.splitContainerGfxMiddle.SuspendLayout();
             this.SuspendLayout();
             // 
             // labelProcessSelect
@@ -1432,7 +1454,7 @@ namespace STROOP
             this.groupBoxObjects.Margin = new System.Windows.Forms.Padding(2);
             this.groupBoxObjects.Name = "groupBoxObjects";
             this.groupBoxObjects.Padding = new System.Windows.Forms.Padding(2);
-            this.groupBoxObjects.Size = new System.Drawing.Size(923, 375);
+            this.groupBoxObjects.Size = new System.Drawing.Size(923, 378);
             this.groupBoxObjects.TabIndex = 2;
             this.groupBoxObjects.TabStop = false;
             this.groupBoxObjects.Text = "Objects";
@@ -1497,7 +1519,7 @@ namespace STROOP
             this.WatchVariablePanelObjects.Location = new System.Drawing.Point(4, 45);
             this.WatchVariablePanelObjects.Margin = new System.Windows.Forms.Padding(2);
             this.WatchVariablePanelObjects.Name = "WatchVariablePanelObjects";
-            this.WatchVariablePanelObjects.Size = new System.Drawing.Size(915, 153);
+            this.WatchVariablePanelObjects.Size = new System.Drawing.Size(915, 156);
             this.WatchVariablePanelObjects.TabIndex = 0;
             this.WatchVariablePanelObjects.Resize += new System.EventHandler(this.WatchVariablePanelObjects_Resize);
             // 
@@ -1536,7 +1558,7 @@ namespace STROOP
             // 
             // splitContainerMain.Panel1
             // 
-            this.splitContainerMain.Panel1.Controls.Add(this.tabControlMain);
+            this.splitContainerMain.Panel1.Controls.Add(this.Gfx);
             this.splitContainerMain.Panel1MinSize = 0;
             // 
             // splitContainerMain.Panel2
@@ -1548,48 +1570,51 @@ namespace STROOP
             this.splitContainerMain.SplitterWidth = 3;
             this.splitContainerMain.TabIndex = 4;
             // 
-            // tabControlMain
+            // Gfx
             // 
-            this.tabControlMain.AllowDrop = true;
-            this.tabControlMain.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            this.Gfx.AllowDrop = true;
+            this.Gfx.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.tabControlMain.Controls.Add(this.tabPageObjects);
-            this.tabControlMain.Controls.Add(this.tabPageMario);
-            this.tabControlMain.Controls.Add(this.tabPageHud);
-            this.tabControlMain.Controls.Add(this.tabPageCamera);
-            this.tabControlMain.Controls.Add(this.tabPageTriangles);
-            this.tabControlMain.Controls.Add(this.tabPageWater);
-            this.tabControlMain.Controls.Add(this.tabPageActions);
-            this.tabControlMain.Controls.Add(this.tabPageInput);
-            this.tabControlMain.Controls.Add(this.tabPageFile);
-            this.tabControlMain.Controls.Add(this.tabPageMisc);
-            this.tabControlMain.Controls.Add(this.tabPageCustom);
-            this.tabControlMain.Controls.Add(this.tabPageDebug);
-            this.tabControlMain.Controls.Add(this.tabPageMap);
-            this.tabControlMain.Controls.Add(this.tabPagePu);
-            this.tabControlMain.Controls.Add(this.tabPageArea);
-            this.tabControlMain.Controls.Add(this.tabPageModel);
-            this.tabControlMain.Controls.Add(this.tabPageDisassembly);
-            this.tabControlMain.Controls.Add(this.tabPageDecompiler);
-            this.tabControlMain.Controls.Add(this.tabPageScripts);
-            this.tabControlMain.Controls.Add(this.tabPageHacks);
-            this.tabControlMain.Controls.Add(this.tabPageCamHack);
-            this.tabControlMain.Controls.Add(this.tabPageQuarterFrame);
-            this.tabControlMain.Controls.Add(this.tabPageVarHack);
-            this.tabControlMain.Controls.Add(this.tabPageOptions);
-            this.tabControlMain.Controls.Add(this.tabPageTesting);
-            this.tabControlMain.HotTrack = true;
-            this.tabControlMain.Location = new System.Drawing.Point(2, 2);
-            this.tabControlMain.Margin = new System.Windows.Forms.Padding(2);
-            this.tabControlMain.Name = "tabControlMain";
-            this.tabControlMain.SelectedIndex = 0;
-            this.tabControlMain.Size = new System.Drawing.Size(923, 489);
-            this.tabControlMain.TabIndex = 3;
+            this.Gfx.Controls.Add(this.tabPageObjects);
+            this.Gfx.Controls.Add(this.tabPageMario);
+            this.Gfx.Controls.Add(this.tabPageHud);
+            this.Gfx.Controls.Add(this.tabPageCamera);
+            this.Gfx.Controls.Add(this.tabPageTriangles);
+            this.Gfx.Controls.Add(this.tabPageWater);
+            this.Gfx.Controls.Add(this.tabPageActions);
+            this.Gfx.Controls.Add(this.tabPageInput);
+            this.Gfx.Controls.Add(this.tabPageFile);
+            this.Gfx.Controls.Add(this.tabPageMisc);
+            this.Gfx.Controls.Add(this.tabPageCustom);
+            this.Gfx.Controls.Add(this.tabPageDebug);
+            this.Gfx.Controls.Add(this.tabPageMap);
+            this.Gfx.Controls.Add(this.tabPagePu);
+            this.Gfx.Controls.Add(this.tabPageArea);
+            this.Gfx.Controls.Add(this.tabPageModel);
+            this.Gfx.Controls.Add(this.tabPageDisassembly);
+            this.Gfx.Controls.Add(this.tabPageDecompiler);
+            this.Gfx.Controls.Add(this.tabPageScripts);
+            this.Gfx.Controls.Add(this.tabPageHacks);
+            this.Gfx.Controls.Add(this.tabPageCamHack);
+            this.Gfx.Controls.Add(this.tabPageQuarterFrame);
+            this.Gfx.Controls.Add(this.tabPageVarHack);
+            this.Gfx.Controls.Add(this.tabPageOptions);
+            this.Gfx.Controls.Add(this.tabPageTesting);
+            this.Gfx.Controls.Add(this.tabPageGfx);
+            this.Gfx.Cursor = System.Windows.Forms.Cursors.Default;
+            this.Gfx.HotTrack = true;
+            this.Gfx.Location = new System.Drawing.Point(2, 2);
+            this.Gfx.Margin = new System.Windows.Forms.Padding(2);
+            this.Gfx.Name = "Gfx";
+            this.Gfx.SelectedIndex = 0;
+            this.Gfx.Size = new System.Drawing.Size(923, 489);
+            this.Gfx.TabIndex = 3;
             // 
             // tabPageObjects
             // 
             this.tabPageObjects.BackColor = System.Drawing.Color.Transparent;
+            this.tabPageObjects.Controls.Add(this.watchVariablePanel1);
             this.tabPageObjects.Controls.Add(this.splitContainerObject);
             this.tabPageObjects.Location = new System.Drawing.Point(4, 22);
             this.tabPageObjects.Margin = new System.Windows.Forms.Padding(0);
@@ -1597,6 +1622,13 @@ namespace STROOP
             this.tabPageObjects.Size = new System.Drawing.Size(915, 463);
             this.tabPageObjects.TabIndex = 0;
             this.tabPageObjects.Text = "Object";
+            // 
+            // watchVariablePanel1
+            // 
+            this.watchVariablePanel1.Location = new System.Drawing.Point(10, 10);
+            this.watchVariablePanel1.Name = "watchVariablePanel1";
+            this.watchVariablePanel1.Size = new System.Drawing.Size(200, 100);
+            this.watchVariablePanel1.TabIndex = 21;
             // 
             // splitContainerObject
             // 
@@ -4688,7 +4720,7 @@ namespace STROOP
             this.tableLayoutPanelFile.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 20F));
             this.tableLayoutPanelFile.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 20F));
             this.tableLayoutPanelFile.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 20F));
-            this.tableLayoutPanelFile.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 219F));
+            this.tableLayoutPanelFile.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 222F));
             this.tableLayoutPanelFile.Controls.Add(this.textBoxTableRow15Col10, 10, 14);
             this.tableLayoutPanelFile.Controls.Add(this.textBoxTableRow14Col10, 10, 13);
             this.tableLayoutPanelFile.Controls.Add(this.textBoxTableRow13Col10, 10, 12);
@@ -8884,7 +8916,7 @@ namespace STROOP
             this.glControlMap.Location = new System.Drawing.Point(4, 3);
             this.glControlMap.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.glControlMap.Name = "glControlMap";
-            this.glControlMap.Size = new System.Drawing.Size(696, 454);
+            this.glControlMap.Size = new System.Drawing.Size(705, 454);
             this.glControlMap.TabIndex = 0;
             this.glControlMap.VSync = false;
             this.glControlMap.Load += new System.EventHandler(this.glControlMap_Load);
@@ -9851,7 +9883,7 @@ namespace STROOP
             // 
             this.splitContainerModelTables.Panel2.Controls.Add(this.labelModelTriangles);
             this.splitContainerModelTables.Panel2.Controls.Add(this.dataGridViewTriangles);
-            this.splitContainerModelTables.Size = new System.Drawing.Size(391, 412);
+            this.splitContainerModelTables.Size = new System.Drawing.Size(340, 412);
             this.splitContainerModelTables.SplitterDistance = 200;
             this.splitContainerModelTables.TabIndex = 2;
             // 
@@ -9883,7 +9915,7 @@ namespace STROOP
             this.dataGridViewVertices.Name = "dataGridViewVertices";
             this.dataGridViewVertices.ReadOnly = true;
             this.dataGridViewVertices.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
-            this.dataGridViewVertices.Size = new System.Drawing.Size(380, 181);
+            this.dataGridViewVertices.Size = new System.Drawing.Size(329, 181);
             this.dataGridViewVertices.TabIndex = 1;
             // 
             // Index
@@ -9939,7 +9971,7 @@ namespace STROOP
             this.dataGridViewTriangles.Name = "dataGridViewTriangles";
             this.dataGridViewTriangles.ReadOnly = true;
             this.dataGridViewTriangles.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
-            this.dataGridViewTriangles.Size = new System.Drawing.Size(380, 189);
+            this.dataGridViewTriangles.Size = new System.Drawing.Size(329, 189);
             this.dataGridViewTriangles.TabIndex = 2;
             // 
             // Group
@@ -12134,6 +12166,70 @@ namespace STROOP
             this.tabPageTesting.TabIndex = 19;
             this.tabPageTesting.Text = "Testing";
             // 
+            // groupBoxTriRooms
+            // 
+            this.groupBoxTriRooms.Controls.Add(this.textBoxTriRoomsToValue);
+            this.groupBoxTriRooms.Controls.Add(this.textBoxTriRoomsFromValue);
+            this.groupBoxTriRooms.Controls.Add(this.buttonTriRoomsConvert);
+            this.groupBoxTriRooms.Controls.Add(this.labelTriRoomsToLabel);
+            this.groupBoxTriRooms.Controls.Add(this.labelTriRoomsFromLabel);
+            this.groupBoxTriRooms.Location = new System.Drawing.Point(760, 259);
+            this.groupBoxTriRooms.Name = "groupBoxTriRooms";
+            this.groupBoxTriRooms.Size = new System.Drawing.Size(116, 99);
+            this.groupBoxTriRooms.TabIndex = 44;
+            this.groupBoxTriRooms.TabStop = false;
+            this.groupBoxTriRooms.Text = "Tri Rooms";
+            // 
+            // textBoxTriRoomsToValue
+            // 
+            this.textBoxTriRoomsToValue.Location = new System.Drawing.Point(40, 42);
+            this.textBoxTriRoomsToValue.Name = "textBoxTriRoomsToValue";
+            this.textBoxTriRoomsToValue.Size = new System.Drawing.Size(67, 20);
+            this.textBoxTriRoomsToValue.TabIndex = 28;
+            this.textBoxTriRoomsToValue.Text = "2";
+            this.textBoxTriRoomsToValue.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
+            // 
+            // textBoxTriRoomsFromValue
+            // 
+            this.textBoxTriRoomsFromValue.Location = new System.Drawing.Point(40, 16);
+            this.textBoxTriRoomsFromValue.Name = "textBoxTriRoomsFromValue";
+            this.textBoxTriRoomsFromValue.Size = new System.Drawing.Size(67, 20);
+            this.textBoxTriRoomsFromValue.TabIndex = 28;
+            this.textBoxTriRoomsFromValue.Text = "1";
+            this.textBoxTriRoomsFromValue.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
+            // 
+            // buttonTriRoomsConvert
+            // 
+            this.buttonTriRoomsConvert.Location = new System.Drawing.Point(12, 67);
+            this.buttonTriRoomsConvert.Margin = new System.Windows.Forms.Padding(2);
+            this.buttonTriRoomsConvert.Name = "buttonTriRoomsConvert";
+            this.buttonTriRoomsConvert.Size = new System.Drawing.Size(95, 23);
+            this.buttonTriRoomsConvert.TabIndex = 16;
+            this.buttonTriRoomsConvert.Text = "Convert";
+            this.buttonTriRoomsConvert.UseVisualStyleBackColor = true;
+            // 
+            // labelTriRoomsToLabel
+            // 
+            this.labelTriRoomsToLabel.AutoSize = true;
+            this.labelTriRoomsToLabel.Location = new System.Drawing.Point(8, 45);
+            this.labelTriRoomsToLabel.MinimumSize = new System.Drawing.Size(20, 2);
+            this.labelTriRoomsToLabel.Name = "labelTriRoomsToLabel";
+            this.labelTriRoomsToLabel.Size = new System.Drawing.Size(23, 13);
+            this.labelTriRoomsToLabel.TabIndex = 18;
+            this.labelTriRoomsToLabel.Text = "To:";
+            this.labelTriRoomsToLabel.TextAlign = System.Drawing.ContentAlignment.TopRight;
+            // 
+            // labelTriRoomsFromLabel
+            // 
+            this.labelTriRoomsFromLabel.AutoSize = true;
+            this.labelTriRoomsFromLabel.Location = new System.Drawing.Point(8, 19);
+            this.labelTriRoomsFromLabel.MinimumSize = new System.Drawing.Size(20, 2);
+            this.labelTriRoomsFromLabel.Name = "labelTriRoomsFromLabel";
+            this.labelTriRoomsFromLabel.Size = new System.Drawing.Size(33, 13);
+            this.labelTriRoomsFromLabel.TabIndex = 18;
+            this.labelTriRoomsFromLabel.Text = "From:";
+            this.labelTriRoomsFromLabel.TextAlign = System.Drawing.ContentAlignment.TopRight;
+            // 
             // groupBoxScuttlebugStuff
             // 
             this.groupBoxScuttlebugStuff.Controls.Add(this.buttonScuttlebugStuffGetTris);
@@ -13717,6 +13813,76 @@ namespace STROOP
             this.labelMetric4Value.Text = "Value";
             this.labelMetric4Value.TextAlign = System.Drawing.ContentAlignment.TopCenter;
             // 
+            // tabPageGfx
+            // 
+            this.tabPageGfx.Controls.Add(this.splitContainerGfxLeft);
+            this.tabPageGfx.Location = new System.Drawing.Point(4, 22);
+            this.tabPageGfx.Name = "tabPageGfx";
+            this.tabPageGfx.Padding = new System.Windows.Forms.Padding(3);
+            this.tabPageGfx.Size = new System.Drawing.Size(915, 463);
+            this.tabPageGfx.TabIndex = 25;
+            this.tabPageGfx.Text = "Gfx";
+            this.tabPageGfx.UseVisualStyleBackColor = true;
+            // 
+            // splitContainerGfxLeft
+            // 
+            this.splitContainerGfxLeft.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.splitContainerGfxLeft.Location = new System.Drawing.Point(3, 3);
+            this.splitContainerGfxLeft.Name = "splitContainerGfxLeft";
+            // 
+            // splitContainerGfxLeft.Panel1
+            // 
+            this.splitContainerGfxLeft.Panel1.Controls.Add(this.treeViewGfx);
+            // 
+            // splitContainerGfxLeft.Panel2
+            // 
+            this.splitContainerGfxLeft.Panel2.Controls.Add(this.splitContainerGfxRight);
+            this.splitContainerGfxLeft.Size = new System.Drawing.Size(909, 457);
+            this.splitContainerGfxLeft.SplitterDistance = 250;
+            this.splitContainerGfxLeft.TabIndex = 0;
+            // 
+            // treeViewGfx
+            // 
+            this.treeViewGfx.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.treeViewGfx.Location = new System.Drawing.Point(0, 0);
+            this.treeViewGfx.Name = "treeViewGfx";
+            this.treeViewGfx.Size = new System.Drawing.Size(250, 457);
+            this.treeViewGfx.TabIndex = 0;
+            // 
+            // splitContainerGfxRight
+            // 
+            this.splitContainerGfxRight.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.splitContainerGfxRight.Location = new System.Drawing.Point(0, 0);
+            this.splitContainerGfxRight.Name = "splitContainerGfxRight";
+            // 
+            // splitContainerGfxRight.Panel1
+            // 
+            this.splitContainerGfxRight.Panel1.Controls.Add(this.splitContainerGfxMiddle);
+            // 
+            // splitContainerGfxRight.Panel2
+            // 
+            this.splitContainerGfxRight.Panel2.Controls.Add(this.richTextBoxGfx);
+            this.splitContainerGfxRight.Size = new System.Drawing.Size(655, 457);
+            this.splitContainerGfxRight.SplitterDistance = 350;
+            this.splitContainerGfxRight.TabIndex = 0;
+            // 
+            // watchVariablePanelGfx
+            // 
+            this.watchVariablePanelGfx.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.watchVariablePanelGfx.Location = new System.Drawing.Point(0, 0);
+            this.watchVariablePanelGfx.Name = "watchVariablePanelGfx";
+            this.watchVariablePanelGfx.Size = new System.Drawing.Size(350, 403);
+            this.watchVariablePanelGfx.TabIndex = 0;
+            // 
+            // richTextBoxGfx
+            // 
+            this.richTextBoxGfx.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.richTextBoxGfx.Location = new System.Drawing.Point(0, 0);
+            this.richTextBoxGfx.Name = "richTextBoxGfx";
+            this.richTextBoxGfx.Size = new System.Drawing.Size(301, 457);
+            this.richTextBoxGfx.TabIndex = 0;
+            this.richTextBoxGfx.Text = "";
+            // 
             // labelVersionNumber
             // 
             this.labelVersionNumber.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
@@ -13904,69 +14070,32 @@ namespace STROOP
             this.buttonShowLeftPane.UseVisualStyleBackColor = true;
             this.buttonShowLeftPane.Click += new System.EventHandler(this.buttonShowLeftPanel_Click);
             // 
-            // groupBoxTriRooms
+            // splitContainerGfxMiddle
             // 
-            this.groupBoxTriRooms.Controls.Add(this.textBoxTriRoomsToValue);
-            this.groupBoxTriRooms.Controls.Add(this.textBoxTriRoomsFromValue);
-            this.groupBoxTriRooms.Controls.Add(this.buttonTriRoomsConvert);
-            this.groupBoxTriRooms.Controls.Add(this.labelTriRoomsToLabel);
-            this.groupBoxTriRooms.Controls.Add(this.labelTriRoomsFromLabel);
-            this.groupBoxTriRooms.Location = new System.Drawing.Point(760, 259);
-            this.groupBoxTriRooms.Name = "groupBoxTriRooms";
-            this.groupBoxTriRooms.Size = new System.Drawing.Size(116, 99);
-            this.groupBoxTriRooms.TabIndex = 44;
-            this.groupBoxTriRooms.TabStop = false;
-            this.groupBoxTriRooms.Text = "Tri Rooms";
+            this.splitContainerGfxMiddle.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.splitContainerGfxMiddle.IsSplitterFixed = true;
+            this.splitContainerGfxMiddle.Location = new System.Drawing.Point(0, 0);
+            this.splitContainerGfxMiddle.Name = "splitContainerGfxMiddle";
+            this.splitContainerGfxMiddle.Orientation = System.Windows.Forms.Orientation.Horizontal;
             // 
-            // textBoxTriRoomsToValue
+            // splitContainerGfxMiddle.Panel1
             // 
-            this.textBoxTriRoomsToValue.Location = new System.Drawing.Point(40, 42);
-            this.textBoxTriRoomsToValue.Name = "textBoxTriRoomsToValue";
-            this.textBoxTriRoomsToValue.Size = new System.Drawing.Size(67, 20);
-            this.textBoxTriRoomsToValue.TabIndex = 28;
-            this.textBoxTriRoomsToValue.Text = "2";
-            this.textBoxTriRoomsToValue.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
+            this.splitContainerGfxMiddle.Panel1.Controls.Add(this.buttonGfxRefresh);
             // 
-            // textBoxTriRoomsFromValue
+            // splitContainerGfxMiddle.Panel2
             // 
-            this.textBoxTriRoomsFromValue.Location = new System.Drawing.Point(40, 16);
-            this.textBoxTriRoomsFromValue.Name = "textBoxTriRoomsFromValue";
-            this.textBoxTriRoomsFromValue.Size = new System.Drawing.Size(67, 20);
-            this.textBoxTriRoomsFromValue.TabIndex = 28;
-            this.textBoxTriRoomsFromValue.Text = "1";
-            this.textBoxTriRoomsFromValue.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
+            this.splitContainerGfxMiddle.Panel2.Controls.Add(this.watchVariablePanelGfx);
+            this.splitContainerGfxMiddle.Size = new System.Drawing.Size(350, 457);
+            this.splitContainerGfxMiddle.TabIndex = 1;
             // 
-            // buttonTriRoomsConvert
+            // buttonGfxRefresh
             // 
-            this.buttonTriRoomsConvert.Location = new System.Drawing.Point(12, 67);
-            this.buttonTriRoomsConvert.Margin = new System.Windows.Forms.Padding(2);
-            this.buttonTriRoomsConvert.Name = "buttonTriRoomsConvert";
-            this.buttonTriRoomsConvert.Size = new System.Drawing.Size(95, 23);
-            this.buttonTriRoomsConvert.TabIndex = 16;
-            this.buttonTriRoomsConvert.Text = "Convert";
-            this.buttonTriRoomsConvert.UseVisualStyleBackColor = true;
-            // 
-            // labelTriRoomsToLabel
-            // 
-            this.labelTriRoomsToLabel.AutoSize = true;
-            this.labelTriRoomsToLabel.Location = new System.Drawing.Point(8, 45);
-            this.labelTriRoomsToLabel.MinimumSize = new System.Drawing.Size(20, 2);
-            this.labelTriRoomsToLabel.Name = "labelTriRoomsToLabel";
-            this.labelTriRoomsToLabel.Size = new System.Drawing.Size(23, 13);
-            this.labelTriRoomsToLabel.TabIndex = 18;
-            this.labelTriRoomsToLabel.Text = "To:";
-            this.labelTriRoomsToLabel.TextAlign = System.Drawing.ContentAlignment.TopRight;
-            // 
-            // labelTriRoomsFromLabel
-            // 
-            this.labelTriRoomsFromLabel.AutoSize = true;
-            this.labelTriRoomsFromLabel.Location = new System.Drawing.Point(8, 19);
-            this.labelTriRoomsFromLabel.MinimumSize = new System.Drawing.Size(20, 2);
-            this.labelTriRoomsFromLabel.Name = "labelTriRoomsFromLabel";
-            this.labelTriRoomsFromLabel.Size = new System.Drawing.Size(33, 13);
-            this.labelTriRoomsFromLabel.TabIndex = 18;
-            this.labelTriRoomsFromLabel.Text = "From:";
-            this.labelTriRoomsFromLabel.TextAlign = System.Drawing.ContentAlignment.TopRight;
+            this.buttonGfxRefresh.Location = new System.Drawing.Point(3, 3);
+            this.buttonGfxRefresh.Name = "buttonGfxRefresh";
+            this.buttonGfxRefresh.Size = new System.Drawing.Size(75, 23);
+            this.buttonGfxRefresh.TabIndex = 0;
+            this.buttonGfxRefresh.Text = "refresh";
+            this.buttonGfxRefresh.UseVisualStyleBackColor = true;
             // 
             // StroopMainForm
             // 
@@ -14000,7 +14129,7 @@ namespace STROOP
             this.splitContainerMain.Panel2.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.splitContainerMain)).EndInit();
             this.splitContainerMain.ResumeLayout(false);
-            this.tabControlMain.ResumeLayout(false);
+            this.Gfx.ResumeLayout(false);
             this.tabPageObjects.ResumeLayout(false);
             this.splitContainerObject.Panel1.ResumeLayout(false);
             this.splitContainerObject.Panel1.PerformLayout();
@@ -14373,6 +14502,8 @@ namespace STROOP
             this.groupBoxShowOverlay.ResumeLayout(false);
             this.groupBoxShowOverlay.PerformLayout();
             this.tabPageTesting.ResumeLayout(false);
+            this.groupBoxTriRooms.ResumeLayout(false);
+            this.groupBoxTriRooms.PerformLayout();
             this.groupBoxScuttlebugStuff.ResumeLayout(false);
             this.groupBoxScuttlebugStuff.PerformLayout();
             this.groupBoxSchedule.ResumeLayout(false);
@@ -14391,10 +14522,21 @@ namespace STROOP
             this.groupBoxGoto.PerformLayout();
             this.groupBoxRecording.ResumeLayout(false);
             this.groupBoxRecording.PerformLayout();
+            this.tabPageGfx.ResumeLayout(false);
+            this.splitContainerGfxLeft.Panel1.ResumeLayout(false);
+            this.splitContainerGfxLeft.Panel2.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.splitContainerGfxLeft)).EndInit();
+            this.splitContainerGfxLeft.ResumeLayout(false);
+            this.splitContainerGfxRight.Panel1.ResumeLayout(false);
+            this.splitContainerGfxRight.Panel2.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.splitContainerGfxRight)).EndInit();
+            this.splitContainerGfxRight.ResumeLayout(false);
             this.panelConnect.ResumeLayout(false);
             this.panelConnect.PerformLayout();
-            this.groupBoxTriRooms.ResumeLayout(false);
-            this.groupBoxTriRooms.PerformLayout();
+            this.splitContainerGfxMiddle.Panel1.ResumeLayout(false);
+            this.splitContainerGfxMiddle.Panel2.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.splitContainerGfxMiddle)).EndInit();
+            this.splitContainerGfxMiddle.ResumeLayout(false);
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -14408,7 +14550,7 @@ namespace STROOP
         private WatchVariablePanel WatchVariablePanelObjects;
         private System.Windows.Forms.SplitContainer splitContainerMain;
         private System.Windows.Forms.CheckBox checkBoxObjLockLabels;
-        private System.Windows.Forms.TabControl tabControlMain;
+        private System.Windows.Forms.TabControl Gfx;
         private System.Windows.Forms.TabPage tabPageObjects;
         private System.Windows.Forms.Label labelObjSlotIndValue;
         private System.Windows.Forms.Label labelObjSlotPosValue;
@@ -15441,6 +15583,15 @@ namespace STROOP
         private Button buttonTriRoomsConvert;
         private Label labelTriRoomsToLabel;
         private Label labelTriRoomsFromLabel;
+        private TabPage tabPageGfx;
+        private WatchVariablePanel watchVariablePanel1;
+        private SplitContainer splitContainerGfxLeft;
+        private TreeView treeViewGfx;
+        private SplitContainer splitContainerGfxRight;
+        private WatchVariablePanel watchVariablePanelGfx;
+        private RichTextBox richTextBoxGfx;
+        private SplitContainer splitContainerGfxMiddle;
+        private Button buttonGfxRefresh;
     }
 }
 

--- a/STROOP/Forms/StroopMainForm.Designer.cs
+++ b/STROOP/Forms/StroopMainForm.Designer.cs
@@ -13831,7 +13831,7 @@ namespace STROOP
             // 
             this.splitContainerGfxLeft.Panel2.Controls.Add(this.splitContainerGfxRight);
             this.splitContainerGfxLeft.Size = new System.Drawing.Size(909, 457);
-            this.splitContainerGfxLeft.SplitterDistance = 250;
+            this.splitContainerGfxLeft.SplitterDistance = 300;
             this.splitContainerGfxLeft.TabIndex = 0;
             // 
             // treeViewGfx
@@ -13840,7 +13840,7 @@ namespace STROOP
             this.treeViewGfx.Dock = System.Windows.Forms.DockStyle.Fill;
             this.treeViewGfx.Location = new System.Drawing.Point(0, 0);
             this.treeViewGfx.Name = "treeViewGfx";
-            this.treeViewGfx.Size = new System.Drawing.Size(250, 457);
+            this.treeViewGfx.Size = new System.Drawing.Size(300, 457);
             this.treeViewGfx.TabIndex = 0;
             // 
             // splitContainerGfxRight
@@ -13856,8 +13856,8 @@ namespace STROOP
             // splitContainerGfxRight.Panel2
             // 
             this.splitContainerGfxRight.Panel2.Controls.Add(this.richTextBoxGfx);
-            this.splitContainerGfxRight.Size = new System.Drawing.Size(655, 457);
-            this.splitContainerGfxRight.SplitterDistance = 350;
+            this.splitContainerGfxRight.Size = new System.Drawing.Size(605, 457);
+            this.splitContainerGfxRight.SplitterDistance = 323;
             this.splitContainerGfxRight.TabIndex = 0;
             // 
             // splitContainerGfxMiddle
@@ -13878,17 +13878,17 @@ namespace STROOP
             // splitContainerGfxMiddle.Panel2
             // 
             this.splitContainerGfxMiddle.Panel2.Controls.Add(this.watchVariablePanelGfx);
-            this.splitContainerGfxMiddle.Size = new System.Drawing.Size(350, 457);
-            this.splitContainerGfxMiddle.SplitterDistance = 40;
+            this.splitContainerGfxMiddle.Size = new System.Drawing.Size(323, 457);
+            this.splitContainerGfxMiddle.SplitterDistance = 60;
             this.splitContainerGfxMiddle.TabIndex = 1;
             // 
             // buttonGfxRefresh
             // 
             this.buttonGfxRefresh.Location = new System.Drawing.Point(3, 3);
             this.buttonGfxRefresh.Name = "buttonGfxRefresh";
-            this.buttonGfxRefresh.Size = new System.Drawing.Size(75, 23);
+            this.buttonGfxRefresh.Size = new System.Drawing.Size(85, 23);
             this.buttonGfxRefresh.TabIndex = 0;
-            this.buttonGfxRefresh.Text = "Refresh root";
+            this.buttonGfxRefresh.Text = "Build from root";
             this.buttonGfxRefresh.UseVisualStyleBackColor = true;
             // 
             // watchVariablePanelGfx
@@ -13896,7 +13896,7 @@ namespace STROOP
             this.watchVariablePanelGfx.Dock = System.Windows.Forms.DockStyle.Fill;
             this.watchVariablePanelGfx.Location = new System.Drawing.Point(0, 0);
             this.watchVariablePanelGfx.Name = "watchVariablePanelGfx";
-            this.watchVariablePanelGfx.Size = new System.Drawing.Size(350, 413);
+            this.watchVariablePanelGfx.Size = new System.Drawing.Size(323, 393);
             this.watchVariablePanelGfx.TabIndex = 0;
             // 
             // richTextBoxGfx
@@ -13905,7 +13905,7 @@ namespace STROOP
             this.richTextBoxGfx.Dock = System.Windows.Forms.DockStyle.Fill;
             this.richTextBoxGfx.Location = new System.Drawing.Point(0, 0);
             this.richTextBoxGfx.Name = "richTextBoxGfx";
-            this.richTextBoxGfx.Size = new System.Drawing.Size(301, 457);
+            this.richTextBoxGfx.Size = new System.Drawing.Size(278, 457);
             this.richTextBoxGfx.TabIndex = 0;
             this.richTextBoxGfx.Text = "";
             // 
@@ -14098,16 +14098,16 @@ namespace STROOP
             // 
             // buttonGfxRefreshObject
             // 
-            this.buttonGfxRefreshObject.Location = new System.Drawing.Point(84, 3);
+            this.buttonGfxRefreshObject.Location = new System.Drawing.Point(94, 3);
             this.buttonGfxRefreshObject.Name = "buttonGfxRefreshObject";
-            this.buttonGfxRefreshObject.Size = new System.Drawing.Size(135, 23);
+            this.buttonGfxRefreshObject.Size = new System.Drawing.Size(147, 23);
             this.buttonGfxRefreshObject.TabIndex = 1;
-            this.buttonGfxRefreshObject.Text = "Refresh selected object";
+            this.buttonGfxRefreshObject.Text = "Build from selected objects";
             this.buttonGfxRefreshObject.UseVisualStyleBackColor = true;
             // 
             // buttonGfxDumpDisplayList
             // 
-            this.buttonGfxDumpDisplayList.Location = new System.Drawing.Point(225, 3);
+            this.buttonGfxDumpDisplayList.Location = new System.Drawing.Point(3, 31);
             this.buttonGfxDumpDisplayList.Name = "buttonGfxDumpDisplayList";
             this.buttonGfxDumpDisplayList.Size = new System.Drawing.Size(104, 23);
             this.buttonGfxDumpDisplayList.TabIndex = 2;

--- a/STROOP/Forms/StroopMainForm.Designer.cs
+++ b/STROOP/Forms/StroopMainForm.Designer.cs
@@ -1593,6 +1593,7 @@ namespace STROOP
             this.Gfx.Controls.Add(this.tabPagePu);
             this.Gfx.Controls.Add(this.tabPageArea);
             this.Gfx.Controls.Add(this.tabPageModel);
+            this.Gfx.Controls.Add(this.tabPageGfx);
             this.Gfx.Controls.Add(this.tabPageDisassembly);
             this.Gfx.Controls.Add(this.tabPageDecompiler);
             this.Gfx.Controls.Add(this.tabPageScripts);
@@ -1602,7 +1603,6 @@ namespace STROOP
             this.Gfx.Controls.Add(this.tabPageVarHack);
             this.Gfx.Controls.Add(this.tabPageOptions);
             this.Gfx.Controls.Add(this.tabPageTesting);
-            this.Gfx.Controls.Add(this.tabPageGfx);
             this.Gfx.Cursor = System.Windows.Forms.Cursors.Default;
             this.Gfx.HotTrack = true;
             this.Gfx.Location = new System.Drawing.Point(2, 2);

--- a/STROOP/Forms/StroopMainForm.Designer.cs
+++ b/STROOP/Forms/StroopMainForm.Designer.cs
@@ -46,7 +46,6 @@ namespace STROOP
             this.splitContainerMain = new System.Windows.Forms.SplitContainer();
             this.Gfx = new System.Windows.Forms.TabControl();
             this.tabPageObjects = new System.Windows.Forms.TabPage();
-            this.watchVariablePanel1 = new STROOP.Controls.WatchVariablePanel();
             this.splitContainerObject = new System.Windows.Forms.SplitContainer();
             this.panelObj = new System.Windows.Forms.Panel();
             this.buttonObjRelease = new STROOP.BinaryButton();
@@ -1614,7 +1613,6 @@ namespace STROOP
             // tabPageObjects
             // 
             this.tabPageObjects.BackColor = System.Drawing.Color.Transparent;
-            this.tabPageObjects.Controls.Add(this.watchVariablePanel1);
             this.tabPageObjects.Controls.Add(this.splitContainerObject);
             this.tabPageObjects.Location = new System.Drawing.Point(4, 22);
             this.tabPageObjects.Margin = new System.Windows.Forms.Padding(0);
@@ -1622,13 +1620,6 @@ namespace STROOP
             this.tabPageObjects.Size = new System.Drawing.Size(915, 463);
             this.tabPageObjects.TabIndex = 0;
             this.tabPageObjects.Text = "Object";
-            // 
-            // watchVariablePanel1
-            // 
-            this.watchVariablePanel1.Location = new System.Drawing.Point(10, 10);
-            this.watchVariablePanel1.Name = "watchVariablePanel1";
-            this.watchVariablePanel1.Size = new System.Drawing.Size(200, 100);
-            this.watchVariablePanel1.TabIndex = 21;
             // 
             // splitContainerObject
             // 
@@ -13843,6 +13834,7 @@ namespace STROOP
             // 
             // treeViewGfx
             // 
+            this.treeViewGfx.BackColor = System.Drawing.SystemColors.Control;
             this.treeViewGfx.Dock = System.Windows.Forms.DockStyle.Fill;
             this.treeViewGfx.Location = new System.Drawing.Point(0, 0);
             this.treeViewGfx.Name = "treeViewGfx";
@@ -13876,6 +13868,7 @@ namespace STROOP
             // 
             // richTextBoxGfx
             // 
+            this.richTextBoxGfx.BackColor = System.Drawing.SystemColors.Control;
             this.richTextBoxGfx.Dock = System.Windows.Forms.DockStyle.Fill;
             this.richTextBoxGfx.Location = new System.Drawing.Point(0, 0);
             this.richTextBoxGfx.Name = "richTextBoxGfx";
@@ -14072,6 +14065,7 @@ namespace STROOP
             // 
             // splitContainerGfxMiddle
             // 
+            this.splitContainerGfxMiddle.BackColor = System.Drawing.SystemColors.Control;
             this.splitContainerGfxMiddle.Dock = System.Windows.Forms.DockStyle.Fill;
             this.splitContainerGfxMiddle.IsSplitterFixed = true;
             this.splitContainerGfxMiddle.Location = new System.Drawing.Point(0, 0);
@@ -15584,7 +15578,6 @@ namespace STROOP
         private Label labelTriRoomsToLabel;
         private Label labelTriRoomsFromLabel;
         private TabPage tabPageGfx;
-        private WatchVariablePanel watchVariablePanel1;
         private SplitContainer splitContainerGfxLeft;
         private TreeView treeViewGfx;
         private SplitContainer splitContainerGfxRight;

--- a/STROOP/Forms/StroopMainForm.cs
+++ b/STROOP/Forms/StroopMainForm.cs
@@ -133,12 +133,12 @@ namespace STROOP
             Config.GfxManager = new GfxManager(tabPageGfx, _gfxData, watchVariablePanelGfx);
 
             // Create Object Slots
-            _slotManagerGui.TabControl = Gfx;
+            _slotManagerGui.TabControl = tabControlMain;
             _slotManagerGui.LockLabelsCheckbox = checkBoxObjLockLabels;
             _slotManagerGui.FlowLayoutContainer = WatchVariablePanelObjects;
             _slotManagerGui.SortMethodComboBox = comboBoxSortMethod;
             _slotManagerGui.LabelMethodComboBox = comboBoxLabelMethod;
-            Config.ObjectSlotsManager = new ObjectSlotsManager(_slotManagerGui, Gfx);
+            Config.ObjectSlotsManager = new ObjectSlotsManager(_slotManagerGui, tabControlMain);
 
             SetupViews();
 
@@ -271,25 +271,25 @@ namespace STROOP
             Invoke(new Action(() =>
             {
                 Config.ObjectSlotsManager.Update();
-                Config.ObjectManager.Update(Gfx.SelectedTab == tabPageObjects);
-                Config.MarioManager.Update(Gfx.SelectedTab == tabPageMario);
-                Config.CameraManager.Update(Gfx.SelectedTab == tabPageCamera);
-                Config.HudManager.Update(Gfx.SelectedTab == tabPageHud);
-                Config.ActionsManager.Update(Gfx.SelectedTab == tabPageActions);
-                Config.WaterManager.Update(Gfx.SelectedTab == tabPageWater);
-                Config.InputManager.Update(Gfx.SelectedTab == tabPageInput);
-                Config.FileManager.Update(Gfx.SelectedTab == tabPageFile);
-                Config.QuarterFrameManager.Update(Gfx.SelectedTab == tabPageQuarterFrame);
-                Config.CustomManager.Update(Gfx.SelectedTab == tabPageCustom);
-                Config.VarHackManager.Update(Gfx.SelectedTab == tabPageVarHack);
-                Config.CameraHackManager.Update(Gfx.SelectedTab == tabPageCamHack);
-                Config.MiscManager.Update(Gfx.SelectedTab == tabPageMisc);
-                Config.TriangleManager.Update(Gfx.SelectedTab == tabPageTriangles);
-                Config.AreaManager.Update(Gfx.SelectedTab == tabPageArea);
-                Config.DebugManager.Update(Gfx.SelectedTab == tabPageDebug);
-                Config.PuManager.Update(Gfx.SelectedTab == tabPagePu);
-                Config.TestingManager.Update(Gfx.SelectedTab == tabPageTesting);
-                Config.GfxManager.Update(Gfx.SelectedTab == tabPageGfx);
+                Config.ObjectManager.Update(tabControlMain.SelectedTab == tabPageObjects);
+                Config.MarioManager.Update(tabControlMain.SelectedTab == tabPageMario);
+                Config.CameraManager.Update(tabControlMain.SelectedTab == tabPageCamera);
+                Config.HudManager.Update(tabControlMain.SelectedTab == tabPageHud);
+                Config.ActionsManager.Update(tabControlMain.SelectedTab == tabPageActions);
+                Config.WaterManager.Update(tabControlMain.SelectedTab == tabPageWater);
+                Config.InputManager.Update(tabControlMain.SelectedTab == tabPageInput);
+                Config.FileManager.Update(tabControlMain.SelectedTab == tabPageFile);
+                Config.QuarterFrameManager.Update(tabControlMain.SelectedTab == tabPageQuarterFrame);
+                Config.CustomManager.Update(tabControlMain.SelectedTab == tabPageCustom);
+                Config.VarHackManager.Update(tabControlMain.SelectedTab == tabPageVarHack);
+                Config.CameraHackManager.Update(tabControlMain.SelectedTab == tabPageCamHack);
+                Config.MiscManager.Update(tabControlMain.SelectedTab == tabPageMisc);
+                Config.TriangleManager.Update(tabControlMain.SelectedTab == tabPageTriangles);
+                Config.AreaManager.Update(tabControlMain.SelectedTab == tabPageArea);
+                Config.DebugManager.Update(tabControlMain.SelectedTab == tabPageDebug);
+                Config.PuManager.Update(tabControlMain.SelectedTab == tabPagePu);
+                Config.TestingManager.Update(tabControlMain.SelectedTab == tabPageTesting);
+                Config.GfxManager.Update(tabControlMain.SelectedTab == tabPageGfx);
                 Config.MapManager?.Update();
                 Config.ModelManager?.Update();
                 Config.InjectionManager.Update();
@@ -429,7 +429,7 @@ namespace STROOP
         private SplitContainer getSelectedTabSplitContainer()
         {
             SplitContainer selectedTabSplitContainer = null;
-            TabPage selectedTabPage = Gfx.SelectedTab;
+            TabPage selectedTabPage = tabControlMain.SelectedTab;
 
             if (selectedTabPage == tabPageObjects)
                 selectedTabSplitContainer = selectedTabPage.Controls["splitContainerObject"] as SplitContainer;
@@ -578,7 +578,7 @@ namespace STROOP
 
         public void SwitchTab(string name)
         {
-            Gfx.SelectTab(name);
+            tabControlMain.SelectTab(name);
         }
     }
 }

--- a/STROOP/Forms/StroopMainForm.cs
+++ b/STROOP/Forms/StroopMainForm.cs
@@ -28,7 +28,7 @@ namespace STROOP
         FileImageGui _fileImageGui = new FileImageGui();
         List<WatchVariableControlPrecursor> _watchVarControlList, _waterData, _miscData, _areaData, _inputData, _fileData,
             _debugData, _camHackData, _hudData, _cameraData, _quarterFrameData, _actionsData,
-            _triangleData, _marioData, _objectData;
+            _triangleData, _marioData, _objectData, _gfxData;
         MapAssociations _mapAssoc;
         ScriptParser _scriptParser;
         List<RomHack> _romHacks;
@@ -130,6 +130,7 @@ namespace STROOP
             Config.OptionsManager = new OptionsManager(tabPageOptions);
             Config.TestingManager = new TestingManager(tabPageTesting);
             Config.ScriptManager = new ScriptManager(tabPageScripts);
+            Config.GfxManager = new GfxManager(tabPageGfx, _gfxData, watchVariablePanelGfx);
 
             // Create Object Slots
             _slotManagerGui.TabControl = Gfx;
@@ -235,7 +236,9 @@ namespace STROOP
             _scriptParser = XmlConfigParser.OpenScripts(@"Config/Scripts.xml");
             loadingForm.UpdateStatus("Loading Hacks", statusNum++);
             _romHacks = XmlConfigParser.OpenHacks(@"Config/Hacks.xml");
+            _gfxData = new List<WatchVariableControlPrecursor>();
             loadingForm.UpdateStatus("Loading Mario Actions", statusNum++);
+
             TableConfig.MarioActions = XmlConfigParser.OpenActionTable(@"Config/MarioActions.xml");
             TableConfig.MarioAnimations = XmlConfigParser.OpenAnimationTable(@"Config/MarioAnimations.xml");
             TableConfig.PendulumSwings = XmlConfigParser.OpenPendulumSwingTable(@"Config/PendulumSwings.xml");
@@ -286,6 +289,7 @@ namespace STROOP
                 Config.DebugManager.Update(Gfx.SelectedTab == tabPageDebug);
                 Config.PuManager.Update(Gfx.SelectedTab == tabPagePu);
                 Config.TestingManager.Update(Gfx.SelectedTab == tabPageTesting);
+                Config.GfxManager.Update(Gfx.SelectedTab == tabPageGfx);
                 Config.MapManager?.Update();
                 Config.ModelManager?.Update();
                 Config.InjectionManager.Update();

--- a/STROOP/Forms/StroopMainForm.cs
+++ b/STROOP/Forms/StroopMainForm.cs
@@ -132,12 +132,12 @@ namespace STROOP
             Config.ScriptManager = new ScriptManager(tabPageScripts);
 
             // Create Object Slots
-            _slotManagerGui.TabControl = tabControlMain;
+            _slotManagerGui.TabControl = Gfx;
             _slotManagerGui.LockLabelsCheckbox = checkBoxObjLockLabels;
             _slotManagerGui.FlowLayoutContainer = WatchVariablePanelObjects;
             _slotManagerGui.SortMethodComboBox = comboBoxSortMethod;
             _slotManagerGui.LabelMethodComboBox = comboBoxLabelMethod;
-            Config.ObjectSlotsManager = new ObjectSlotsManager(_slotManagerGui, tabControlMain);
+            Config.ObjectSlotsManager = new ObjectSlotsManager(_slotManagerGui, Gfx);
 
             SetupViews();
 
@@ -268,24 +268,24 @@ namespace STROOP
             Invoke(new Action(() =>
             {
                 Config.ObjectSlotsManager.Update();
-                Config.ObjectManager.Update(tabControlMain.SelectedTab == tabPageObjects);
-                Config.MarioManager.Update(tabControlMain.SelectedTab == tabPageMario);
-                Config.CameraManager.Update(tabControlMain.SelectedTab == tabPageCamera);
-                Config.HudManager.Update(tabControlMain.SelectedTab == tabPageHud);
-                Config.ActionsManager.Update(tabControlMain.SelectedTab == tabPageActions);
-                Config.WaterManager.Update(tabControlMain.SelectedTab == tabPageWater);
-                Config.InputManager.Update(tabControlMain.SelectedTab == tabPageInput);
-                Config.FileManager.Update(tabControlMain.SelectedTab == tabPageFile);
-                Config.QuarterFrameManager.Update(tabControlMain.SelectedTab == tabPageQuarterFrame);
-                Config.CustomManager.Update(tabControlMain.SelectedTab == tabPageCustom);
-                Config.VarHackManager.Update(tabControlMain.SelectedTab == tabPageVarHack);
-                Config.CameraHackManager.Update(tabControlMain.SelectedTab == tabPageCamHack);
-                Config.MiscManager.Update(tabControlMain.SelectedTab == tabPageMisc);
-                Config.TriangleManager.Update(tabControlMain.SelectedTab == tabPageTriangles);
-                Config.AreaManager.Update(tabControlMain.SelectedTab == tabPageArea);
-                Config.DebugManager.Update(tabControlMain.SelectedTab == tabPageDebug);
-                Config.PuManager.Update(tabControlMain.SelectedTab == tabPagePu);
-                Config.TestingManager.Update(tabControlMain.SelectedTab == tabPageTesting);
+                Config.ObjectManager.Update(Gfx.SelectedTab == tabPageObjects);
+                Config.MarioManager.Update(Gfx.SelectedTab == tabPageMario);
+                Config.CameraManager.Update(Gfx.SelectedTab == tabPageCamera);
+                Config.HudManager.Update(Gfx.SelectedTab == tabPageHud);
+                Config.ActionsManager.Update(Gfx.SelectedTab == tabPageActions);
+                Config.WaterManager.Update(Gfx.SelectedTab == tabPageWater);
+                Config.InputManager.Update(Gfx.SelectedTab == tabPageInput);
+                Config.FileManager.Update(Gfx.SelectedTab == tabPageFile);
+                Config.QuarterFrameManager.Update(Gfx.SelectedTab == tabPageQuarterFrame);
+                Config.CustomManager.Update(Gfx.SelectedTab == tabPageCustom);
+                Config.VarHackManager.Update(Gfx.SelectedTab == tabPageVarHack);
+                Config.CameraHackManager.Update(Gfx.SelectedTab == tabPageCamHack);
+                Config.MiscManager.Update(Gfx.SelectedTab == tabPageMisc);
+                Config.TriangleManager.Update(Gfx.SelectedTab == tabPageTriangles);
+                Config.AreaManager.Update(Gfx.SelectedTab == tabPageArea);
+                Config.DebugManager.Update(Gfx.SelectedTab == tabPageDebug);
+                Config.PuManager.Update(Gfx.SelectedTab == tabPagePu);
+                Config.TestingManager.Update(Gfx.SelectedTab == tabPageTesting);
                 Config.MapManager?.Update();
                 Config.ModelManager?.Update();
                 Config.InjectionManager.Update();
@@ -425,7 +425,7 @@ namespace STROOP
         private SplitContainer getSelectedTabSplitContainer()
         {
             SplitContainer selectedTabSplitContainer = null;
-            TabPage selectedTabPage = tabControlMain.SelectedTab;
+            TabPage selectedTabPage = Gfx.SelectedTab;
 
             if (selectedTabPage == tabPageObjects)
                 selectedTabSplitContainer = selectedTabPage.Controls["splitContainerObject"] as SplitContainer;
@@ -574,7 +574,7 @@ namespace STROOP
 
         public void SwitchTab(string name)
         {
-            tabControlMain.SelectTab(name);
+            Gfx.SelectTab(name);
         }
     }
 }

--- a/STROOP/Managers/GfxManager.cs
+++ b/STROOP/Managers/GfxManager.cs
@@ -28,7 +28,7 @@ namespace STROOP.Managers
             var right = left.Panel2.Controls["splitContainerGfxright"] as SplitContainer;
             var middle = right.Panel1.Controls["splitContainerGfxmiddle"] as SplitContainer;
             var output = right.Panel2.Controls["richTextBoxGfx"] as RichTextBox;
-            var refreshButtonRoot = middle.Panel1.Controls["buttonGfxRefreshRoot"] as Button;
+            var refreshButtonRoot = middle.Panel1.Controls["buttonGfxRefresh"] as Button;
             var refreshButtonObject = middle.Panel1.Controls["buttonGfxRefreshObject"] as Button;
             var dumpButton = middle.Panel1.Controls["buttonGfxDumpDisplayList"] as Button;
 
@@ -138,9 +138,9 @@ namespace STROOP.Managers
                 case 0x00B: res = new GfxHeightGate(); break;
                 case 0x015: res = new GfxUnknown15(); break;
                 case 0x016: res = new GfxUnknown16(); break;
-                case 0x017: res = new GfxTransformNode(); break;
+                case 0x017: res = new GfxRotationNode(); break;
                 case 0x018: res = new GfxGameObject(); break;
-                case 0x019: res = new GfxAnimationNode(); break;
+                case 0x019: res = new GfxTranslationNode(); break;
                 case 0x01A: res = new GfxMenuModel(); break;
                 case 0x01B: res = new GfxDisplayList(); break;
                 case 0x01C: res = new GfxScalingNode(); break;
@@ -229,6 +229,7 @@ namespace STROOP.Managers
         public override List<WatchVariableControlPrecursor> GetTypeSpecificVariables()
         {
             var res = new List<WatchVariableControlPrecursor>();
+            res.Add(gfxProperty("Selection function", "uint", 0x14));
             res.Add(gfxProperty("Selected child", "ushort", 0x1E));
             return res;
         }
@@ -264,6 +265,13 @@ namespace STROOP.Managers
     internal class GfxProjection3D : GfxNode
     {
         public override string Name { get { return "Projection 3D"; } }
+        public override List<WatchVariableControlPrecursor> GetTypeSpecificVariables()
+        {
+            var res = new List<WatchVariableControlPrecursor>();
+            res.Add(gfxProperty("znear", "short", 0x14));
+            res.Add(gfxProperty("zfar", "short", 0x14));
+            return res;
+        }
     }
 
     internal class GfxObjectParent : GfxNode
@@ -280,21 +288,53 @@ namespace STROOP.Managers
     internal class GfxShadowNode : GfxNode
     {
         public override string Name { get { return "Shadow"; } }
+        public override List<WatchVariableControlPrecursor> GetTypeSpecificVariables()
+        {
+            var res = new List<WatchVariableControlPrecursor>();
+            res.Add(gfxProperty("radius", "short", 0x14));
+            res.Add(gfxProperty("opacity", "ubyte", 0x16));
+            res.Add(gfxProperty("type", "byte", 0x17));
+            return res;
+        }
     }
 
     internal class GfxScalingNode : GfxNode
     {
         public override string Name { get { return "Scaling node"; } }
+        public override List<WatchVariableControlPrecursor> GetTypeSpecificVariables()
+        {
+            var res = new List<WatchVariableControlPrecursor>();
+            res.Add(gfxProperty("Scale", "float", 0x18));
+            return res;
+        }
     }
 
+    // Temporary name. This is used to draw the "S U P E R M A R I O" in debug level select
     internal class GfxMenuModel : GfxNode
     {
         public override string Name { get { return "Menu model"; } }
+        public override List<WatchVariableControlPrecursor> GetTypeSpecificVariables()
+        {
+            var res = new List<WatchVariableControlPrecursor>();
+            res.Add(gfxProperty("Segmented address", "uint", 0x14));
+            res.Add(gfxProperty("x offset", "short", 0x18)); //todo: check these
+            res.Add(gfxProperty("y offset", "short", 0x1A));
+            return res;
+        }
     }
 
-    internal class GfxAnimationNode : GfxNode
+    internal class GfxTranslationNode : GfxNode
     {
         public override string Name { get { return "Animation"; } }
+        public override List<WatchVariableControlPrecursor> GetTypeSpecificVariables()
+        {
+            var res = new List<WatchVariableControlPrecursor>();
+            res.Add(gfxProperty("Segmented address", "uint", 0x14));
+            res.Add(gfxProperty("x", "short", 0x18));
+            res.Add(gfxProperty("y", "short", 0x1A));
+            res.Add(gfxProperty("z", "short", 0x1C));
+            return res;
+        }
     }
 
     internal class GfxGameObject : GfxNode
@@ -302,9 +342,19 @@ namespace STROOP.Managers
         public override string Name { get { return "Game object"; } }
     }
 
-    internal class GfxTransformNode : GfxNode
+    internal class GfxRotationNode : GfxNode
     {
         public override string Name { get { return "Transformation"; } }
+
+        public override List<WatchVariableControlPrecursor> GetTypeSpecificVariables()
+        {
+            var res = new List<WatchVariableControlPrecursor>();
+            res.Add(gfxProperty("Segmented address", "uint", 0x14));
+            res.Add(gfxProperty("angle x", "short", 0x18));
+            res.Add(gfxProperty("angle y", "short", 0x1A));
+            res.Add(gfxProperty("angle z", "short", 0x1C));
+            return res;
+        }
     }
 
     internal class GfxUnknown16 : GfxNode
@@ -340,10 +390,26 @@ namespace STROOP.Managers
     internal class GfxRootnode : GfxNode
     {
         public override string Name { get { return "Root"; } }
+        public override List<WatchVariableControlPrecursor> GetTypeSpecificVariables()
+        {
+            var res = new List<WatchVariableControlPrecursor>();
+            res.Add(gfxProperty("Some short", "short", 0x14));
+            res.Add(gfxProperty("Screen xoffset", "short", 0x16));
+            res.Add(gfxProperty("Screen yoffset", "short", 0x18));
+            res.Add(gfxProperty("Screen half width", "short", 0x1A));
+            res.Add(gfxProperty("Screen half height", "short", 0x1C));
+            return res;
+        }
     }
 
     internal class GfxDisplayList : GfxNode
     {
         public override string Name { get { return "DisplayList"; } }
+        public override List<WatchVariableControlPrecursor> GetTypeSpecificVariables()
+        {
+            var res = new List<WatchVariableControlPrecursor>();
+            res.Add(gfxProperty("Segmented address", "uint", 0x14));
+            return res;
+        }
     }
 }

--- a/STROOP/Managers/GfxManager.cs
+++ b/STROOP/Managers/GfxManager.cs
@@ -87,14 +87,16 @@ namespace STROOP.Managers
         // Build a GFX tree for every object that is selected in the object slot view
         private void RefreshButtonObject_Click(object sender, EventArgs e)
         {
-            _treeView.Nodes.Clear();
+            
             var list = Config.ObjectSlotsManager.SelectedSlotsAddresses;
             if (list != null && list.Count>0)
             {
-                foreach(var address in list)
+                _treeView.Nodes.Clear();
+                foreach (var address in list)
                 {
                     AddToTreeView(address);
                 }
+                ExpandNodesUpTo(_treeView.Nodes, 4);
             }
             else
             {
@@ -121,12 +123,24 @@ namespace STROOP.Managers
 
             // A pointer to the root node of the GFX tree is stored at a fixed address
             AddToTreeView(Config.Stream.GetUInt32(Config.SwitchRomVersion(0x33B910, 0x33A5A0)));
+            ExpandNodesUpTo(_treeView.Nodes, 4);
+        }
+
+        // By default, a new TreeNode is collapsed. If you expand all, then the treeview will be overwhelmed with 240 object nodes
+        // This function allows to expand only the nodes a certain amount of levels deep while keeping the deeper ones collapsed
+        private void ExpandNodesUpTo(TreeNodeCollection nodes, int level) {
+            if (level <= 0) return;
+
+            foreach (TreeNode node in nodes)
+            {
+                node.Expand();
+                ExpandNodesUpTo(node.Nodes, level-1);
+            }
         }
 
         public void AddToTreeView(uint rootAddress)
         {
             var root = GfxNode.ReadGfxNode(rootAddress);
-            
             _treeView.Nodes.Add(GfxToTreeNode(root));
         }
 
@@ -397,7 +411,7 @@ namespace STROOP.Managers
 
     internal class GfxTranslationNode : GfxNode
     {
-        public override string Name { get { return "Animation"; } }
+        public override string Name { get { return "Translation"; } }
         public override List<WatchVariableControlPrecursor> GetTypeSpecificVariables()
         {
             var res = new List<WatchVariableControlPrecursor>();

--- a/STROOP/Managers/GfxManager.cs
+++ b/STROOP/Managers/GfxManager.cs
@@ -1,0 +1,252 @@
+﻿using STROOP.Controls;
+using System;
+using System.Collections.Generic;
+using System.Windows.Forms;
+using System.Linq;
+using STROOP.Structs.Configurations;
+
+namespace STROOP.Managers
+{
+    public class GfxManager : DataManager
+    {
+        Control _tabControl;
+        TreeView _treeView;
+        GfxNode currentNode;
+
+        public GfxManager(Control tabControl, List<WatchVariableControlPrecursor> variables, WatchVariablePanel watchVariablePanel)
+            : base(variables, watchVariablePanel)
+        {
+            var left = tabControl.Controls["splitContainerGfxLeft"] as SplitContainer;
+            var right = left.Panel2.Controls["splitContainerGfxright"] as SplitContainer;
+            var middle = right.Panel1.Controls["splitContainerGfxmiddle"] as SplitContainer;
+            var output = right.Panel2.Controls["richTextBoxGfx"] as RichTextBox;
+            var refreshButton = middle.Panel1.Controls["buttonGfxRefresh"] as Button;
+            
+            _treeView = left.Panel1.Controls["treeViewGfx"] as TreeView;
+            _treeView.AfterSelect += _treeView_AfterSelect;
+            refreshButton.Click += RefreshButton_Click;
+            _tabControl = tabControl;
+
+            var wv = new WatchVariable("uint", null, Structs.BaseAddressTypeEnum.Relative, 0x8032D5D4, 0x8032C694, null, null, null);
+            var wvp = new WatchVariableControlPrecursor("Global timer", wv, Structs.WatchVariableSubclass.Number, System.Drawing.Color.Goldenrod, true, false, null, new List<Structs.VariableGroup>());
+            var wvc = wvp.CreateWatchVariableControl();
+            watchVariablePanel.AddVariable(wvc);
+            watchVariablePanel.AddVariable(wvc);
+            watchVariablePanel.AddVariable(wvc);
+            watchVariablePanel.AddVariable(wvc);
+            watchVariablePanel.AddVariable(wvc);
+            watchVariablePanel.AddVariable(wvc);
+            watchVariablePanel.AddVariable(wvc);
+            watchVariablePanel.AddVariable(wvc);
+            watchVariablePanel.AddVariable(wvc);
+            watchVariablePanel.AddVariable(wvc);
+            watchVariablePanel.AddVariable(wvc);
+            watchVariablePanel.AddVariable(wvc);
+            watchVariablePanel.AddVariable(wvc);
+            watchVariablePanel.AddVariable(wvc);
+            watchVariablePanel.AddVariable(wvc);
+            watchVariablePanel.AddVariable(wvc);
+        }
+
+        private void _treeView_AfterSelect(object sender, TreeViewEventArgs e)
+        {
+            GfxNode node = (GfxNode)e.Node.Tag;
+            MessageBox.Show(node.name);
+        }
+
+        private void RefreshButton_Click(object sender, EventArgs e)
+        {
+            //Config.SwitchRomVersion(0x33A5A0, 0x33A5A0);
+            var root = GfxNode.ReadGfxNode(Config.Stream.GetUInt32(0x33A5A0));
+            _treeView.Nodes.Add("Test");
+            _treeView.Nodes.Add(GfxToTreeNode(root));
+        }
+
+        public override void Update(bool updateView)
+        {
+            if (!updateView) return;
+            base.Update(true);
+        }
+
+        public TreeNode GfxToTreeNode(GfxNode node)
+        {
+            if (node == null) return new TreeNode("Invalid Gfx Node");
+            TreeNode res = new TreeNode(node.name, node.children.Select(x => GfxToTreeNode(x)).ToArray());
+            res.Tag = node;
+            return res;
+        }
+    }
+
+    public class GfxNode
+    {
+        private const int maxSiblings = 1000; //To prevent infinite loops on malformed memory
+
+        public string name = "GFX node";
+        public uint address;
+        GfxNode parent;
+        public List<GfxNode> children;
+
+        public static GfxNode ReadGfxNode(uint address)
+        {
+            if (address < 0x80000000u || address > 0x80800000u)
+            {
+                return null;
+            }
+
+            var type = Config.Stream.GetUInt16(address + 0x00);
+            GfxNode res;
+
+            switch (type)
+            {
+                case 0x001: res = new GfxRootnode(); break;
+                case 0x002: res = new GfxScreenSpace(); break;
+                case 0x004: res = new GfxMasterList(); break;
+                case 0x00A: res = new GfxRoomObjectParent(); break;
+                case 0x00B: res = new GfxHeightGate(); break;
+                case 0x015: res = new GfxUnknown15(); break;
+                case 0x016: res = new GfxUnknown16(); break;
+                case 0x017: res = new GfxTransformNode(); break;
+                case 0x018: res = new GfxGameObject(); break;
+                case 0x019: res = new GfxAnimationNode(); break;
+                case 0x01A: res = new GfxMenuModel(); break;
+                case 0x01B: res = new GfxDisplayList(); break;
+                case 0x01C: res = new GfxScalingNode(); break;
+                case 0x028: res = new GfxShadowNode(); break;
+                case 0x029: res = new GfxObjectParent(); break;
+                case 0x103: res = new GfxProjection3D(); break;
+                case 0x10C: res = new GfxChildSelector(); break;
+                case 0x114: res = new GfxCamera(); break;
+                case 0x12A: res = new GfxGeoLayoutScript(); break;
+                case 0x12C: res = new GfxBackgroundImage(); break;
+                case 0x12E: res = new GfxHeldObject(); break;
+                default: res = new GfxNode(); break;
+            }
+            res.address = address;
+            res.children = new List<GfxNode>();
+            var childAddress = Config.Stream.GetUInt32(address + 0x10);  //offset 0x10 = child pointer
+
+            if (childAddress != 0)
+            {
+                var currentAddress = childAddress;
+                for (int i = 0; i < maxSiblings; i++)
+                {
+                    res.children.Add(ReadGfxNode(currentAddress));
+                    currentAddress = Config.Stream.GetUInt32(currentAddress + 0x08); //offset 0x08 = next pointer
+                    if (currentAddress == childAddress) break;
+                }
+            }
+
+            return res;
+        }
+
+        public virtual List<WatchVariableControlPrecursor> getSpecialVars()
+        {
+            return new List<WatchVariableControlPrecursor>();
+        }
+    }
+
+    internal class GfxChildSelector : GfxNode
+    {
+        new string name = "Child selector";
+    }
+
+    internal class GfxBackgroundImage : GfxNode
+    {
+        new string name = "Background image";
+    }
+
+    internal class GfxHeldObject : GfxNode
+    {
+        new string name = "Held object";
+    }
+
+    internal class GfxGeoLayoutScript : GfxNode
+    {
+        new string name = "Geo Layout script";
+    }
+
+    internal class GfxCamera : GfxNode
+    {
+        new string name = "Camera";
+    }
+
+    internal class GfxProjection3D : GfxNode
+    {
+        new string name = "Projection 3D";
+    }
+
+    internal class GfxObjectParent : GfxNode
+    {
+        new string name = "Object parent";
+    }
+
+    internal class GfxShadowNode : GfxNode
+    {
+        new string name = "Shadow";
+    }
+
+    internal class GfxScalingNode : GfxNode
+    {
+        new string name = "Scaling node";
+    }
+
+    internal class GfxMenuModel : GfxNode
+    {
+        new string name = "Menu model";
+    }
+
+    internal class GfxAnimationNode : GfxNode
+    {
+        new string name = "Animation";
+    }
+
+    internal class GfxGameObject : GfxNode
+    {
+        new string name = "Game object";
+    }
+
+    internal class GfxTransformNode : GfxNode
+    {
+        new string name = "Transformation";
+    }
+
+    internal class GfxUnknown16 : GfxNode
+    {
+        new string name = "Unknown 0x16";
+    }
+
+    internal class GfxUnknown15 : GfxNode
+    {
+        new string name = "Unknown 0x15";
+    }
+
+    internal class GfxHeightGate : GfxNode
+    {
+        new string name = "Height gate";
+    }
+
+    internal class GfxMasterList : GfxNode
+    {
+        new string name = "Master list";
+    }
+
+    internal class GfxRoomObjectParent : GfxNode
+    {
+        new string name = "Room/Object parent";
+    }
+
+    internal class GfxScreenSpace : GfxNode
+    {
+        new string name = "Screenspace";
+    }
+
+    internal class GfxRootnode : GfxNode
+    {
+        new string name = "Root";
+    }
+
+    internal class GfxDisplayList : GfxNode
+    {
+        new string name = "DisplayList";
+    }
+}

--- a/STROOP/Managers/GfxManager.cs
+++ b/STROOP/Managers/GfxManager.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Windows.Forms;
+using System.Drawing;
 using System.Linq;
 using STROOP.Structs.Configurations;
 using STROOP.Utilities;
@@ -247,10 +248,13 @@ namespace STROOP.Managers
         }
 
         // Wrapper to make defining variables easier
-        protected static WatchVariableControlPrecursor gfxProperty(string name, string type, uint offset, Structs.WatchVariableSubclass subclass = Structs.WatchVariableSubclass.Number, uint? mask = null)
+        protected static WatchVariableControlPrecursor gfxProperty(string name, string type, uint offset, 
+            Structs.WatchVariableSubclass subclass = Structs.WatchVariableSubclass.Number, uint? mask = null)
         {
+            var col = (offset <= 0x13) ? Color.Beige : Color.PowderBlue;
             var wv = new WatchVariable(type, null, Structs.BaseAddressTypeEnum.GfxNode, offset, offset, offset, offset, mask);
-            var wvp = new WatchVariableControlPrecursor(name, wv, subclass, (offset <= 0x13) ? System.Drawing.Color.Beige : System.Drawing.Color.PowderBlue, true, false, null, new List<Structs.VariableGroup>());
+            var wvp = new WatchVariableControlPrecursor(name, wv, subclass, col, 
+                type == "uint" || type == "ushort", false, null, new List<Structs.VariableGroup>());
             return wvp;
         }
 
@@ -282,6 +286,21 @@ namespace STROOP.Managers
     internal class GfxHeldObject : GfxNode
     {
         public override string Name { get { return "Held object"; } }
+        //function gfxFunction  0x14
+        //int marioOffset  0x18        memory offset from marioData to check
+        //void* heldObj      0x1c        another struct
+        //short[3] position     0x20,2,4
+        public override List<WatchVariableControlPrecursor> GetTypeSpecificVariables()
+        {
+            var res = new List<WatchVariableControlPrecursor>();
+            res.Add(gfxProperty("Function", "uint", 0x14));
+            res.Add(gfxProperty("Mario offset", "int", 0x18));
+            res.Add(gfxProperty("Held object", "uint", 0x1C));
+            res.Add(gfxProperty("Position x", "short", 0x20));
+            res.Add(gfxProperty("Position y", "short", 0x22));
+            res.Add(gfxProperty("Position z", "short", 0x24));
+            return res;
+        }
     }
 
     internal class GfxGeoLayoutScript : GfxNode
@@ -302,12 +321,13 @@ namespace STROOP.Managers
         public override List<WatchVariableControlPrecursor> GetTypeSpecificVariables()
         {
             var res = new List<WatchVariableControlPrecursor>();
-            res.Add(gfxProperty("x from", "float", 0x1C));
-            res.Add(gfxProperty("y from", "float", 0x20));
-            res.Add(gfxProperty("z from", "float", 0x24));
-            res.Add(gfxProperty("x2 from", "float", 0x28));
-            res.Add(gfxProperty("y2 from", "float", 0x2C));
-            res.Add(gfxProperty("z2 from", "float", 0x30));
+            res.Add(gfxProperty("Update function", "uint", 0x14));
+            res.Add(gfxProperty("X from", "float", 0x1C));
+            res.Add(gfxProperty("X from", "float", 0x20));
+            res.Add(gfxProperty("Z from", "float", 0x24));
+            res.Add(gfxProperty("X to", "float", 0x28));
+            res.Add(gfxProperty("Y to", "float", 0x2C));
+            res.Add(gfxProperty("Z to", "float", 0x30));
             return res;
         }
     }
@@ -318,9 +338,10 @@ namespace STROOP.Managers
         public override List<WatchVariableControlPrecursor> GetTypeSpecificVariables()
         {
             var res = new List<WatchVariableControlPrecursor>();
-            res.Add(gfxProperty("angle", "float", 0x1C));
-            res.Add(gfxProperty("znear", "short", 0x20));
-            res.Add(gfxProperty("zfar", "short", 0x22));
+            res.Add(gfxProperty("Update function", "uint", 0x14));
+            res.Add(gfxProperty("Fov", "float", 0x1C));
+            res.Add(gfxProperty("Z clip near", "short", 0x20));
+            res.Add(gfxProperty("Z clip far", "short", 0x22));
             return res;
         }
     }
@@ -368,8 +389,8 @@ namespace STROOP.Managers
         {
             var res = new List<WatchVariableControlPrecursor>();
             res.Add(gfxProperty("Segmented address", "uint", 0x14));
-            res.Add(gfxProperty("x offset", "short", 0x18)); //todo: check these
-            res.Add(gfxProperty("y offset", "short", 0x1A));
+            res.Add(gfxProperty("X offset", "short", 0x18)); //todo: check these
+            res.Add(gfxProperty("Y offset", "short", 0x1A));
             return res;
         }
     }
@@ -381,9 +402,9 @@ namespace STROOP.Managers
         {
             var res = new List<WatchVariableControlPrecursor>();
             res.Add(gfxProperty("Segmented address", "uint", 0x14));
-            res.Add(gfxProperty("x", "short", 0x18));
-            res.Add(gfxProperty("y", "short", 0x1A));
-            res.Add(gfxProperty("z", "short", 0x1C));
+            res.Add(gfxProperty("X", "short", 0x18));
+            res.Add(gfxProperty("Y", "short", 0x1A));
+            res.Add(gfxProperty("Z", "short", 0x1C));
             return res;
         }
     }
@@ -407,9 +428,9 @@ namespace STROOP.Managers
         {
             var res = new List<WatchVariableControlPrecursor>();
             res.Add(gfxProperty("Segmented address", "uint", 0x14));
-            res.Add(gfxProperty("angle x", "short", 0x18));
-            res.Add(gfxProperty("angle y", "short", 0x1A));
-            res.Add(gfxProperty("angle z", "short", 0x1C));
+            res.Add(gfxProperty("Angle x", "short", 0x18)); //Todo: make these angle types
+            res.Add(gfxProperty("Angle y", "short", 0x1A));
+            res.Add(gfxProperty("Angle z", "short", 0x1C));
             return res;
         }
     }

--- a/STROOP/STROOP.csproj
+++ b/STROOP/STROOP.csproj
@@ -230,6 +230,7 @@
     <Compile Include="LoadingHandler.cs" />
     <Compile Include="Managers\AreaManager.cs" />
     <Compile Include="Managers\CamHackManager.cs" />
+    <Compile Include="Managers\GfxManager.cs" />
     <Compile Include="Managers\VarHackManager.cs" />
     <Compile Include="Managers\DecompilerManager.cs" />
     <Compile Include="Managers\CustomManager.cs" />

--- a/STROOP/STROOP.csproj
+++ b/STROOP/STROOP.csproj
@@ -314,6 +314,7 @@
     <Compile Include="Enums\WatchVariableSubclass.cs" />
     <Compile Include="Enums\VariableGroup.cs" />
     <Compile Include="Enums\BaseAddressTypeEnum.cs" />
+    <Compile Include="Utilities\Fast3DDecoder.cs" />
     <Compile Include="Utilities\WatchVariableSpecialUtilities.cs" />
     <Compile Include="Utilities\WatchVariableCoordinateManager.cs" />
     <Compile Include="Utilities\AreaUtilities.cs" />

--- a/STROOP/Structs/Configurations/Config.cs
+++ b/STROOP/Structs/Configurations/Config.cs
@@ -77,5 +77,6 @@ namespace STROOP.Structs.Configurations
         public static VarHackManager VarHackManager;
         public static DataManager CameraHackManager;
         public static ScriptManager ScriptManager;
+        public static GfxManager GfxManager;
     }
 }

--- a/STROOP/Utilities/Fast3DDecoder.cs
+++ b/STROOP/Utilities/Fast3DDecoder.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using STROOP.Structs.Configurations;
+
+namespace STROOP.Utilities
+{
+    public class Fast3DDecoder
+    {
+        private const int MaxDisplayListLength = 5000; 
+
+        public enum F3DOpcode
+        {
+            // DMA |00xxxxxx|
+            G_NOOP = 0x00,
+            G_MTX = 0x01,
+            G_RESERVED0 = 0x02,
+            G_MOVEMEM = 0x03,
+            G_VTX = 0x04,
+            G_RESERVED1 = 0x05,
+            G_DL = 0x06,
+            G_RESERVED2 = 0x07,
+            G_RESERVED3 = 0x08,
+            G_SPRITE2D_BASE = 0x09,
+
+            // Immediate Mode |10xxxxxx|
+            G_RDPHALF_2 = 0xB3,
+            G_RDPHALF_1 = 0xB4,
+            G_LINE3D = 0xB5,
+            G_CLEARGEOMETRYMODE = 0xB6,
+            G_SETGEOMETRYMODE = 0xB7,
+            G_ENDDL = 0xB8,
+            G_SETOTHERMODE_L = 0xB9,
+            G_SETOTHERMODE_H = 0xBA,
+            G_TEXTURE = 0xBB,
+            G_MOVEWORD = 0xBC,
+            G_POPMTX = 0xBD,
+            G_CULLDL = 0xBE,
+            G_TRI1 = 0xBF,
+
+            // RDP |11xxxxxx|
+            G_TEXRECT = 0xE4,
+            G_TEXRECTFLIP = 0xE5,
+            G_RDPLOADSYNC = 0xE6,
+            G_RDPPIPESYNC = 0xE7,
+            G_RDPTILESYNC = 0xE8,
+            G_RDPFULLSYNC = 0xE9,
+            G_SETKEYGB = 0xEA,
+            G_SETKEYR = 0xEB,
+            G_SETCONVERT = 0xEC,
+            G_SETSCISSOR = 0xED,
+            G_SETPRIMDEPTH = 0xEE,
+            G_RDPSETOTHERMODE = 0xEF,
+            G_LOADTLUT = 0xF0,
+            G_SETTILESIZE = 0xF2,
+            G_LOADBLOCK = 0xF3,
+            G_LOADTILE = 0xF4,
+            G_SETTILE = 0xF5,
+            G_FILLRECT = 0xF6,
+            G_SETFILLCOLOR = 0xF7,
+            G_SETFOGCOLOR = 0xF8,
+            G_SETBLENDCOLOR = 0xF9,
+            G_SETPRIMCOLOR = 0xFA,
+            G_SETENVCOLOR = 0xFB,
+            G_SETCOMBINE = 0xFC,
+            G_SETTIMG = 0xFD,
+            G_SETZIMG = 0xFE,
+            G_SETCIMG = 0xFF,
+        }
+
+        public static string DecodeList(uint address)
+        {
+            var res = new StringBuilder();
+
+            for(int i = 0; i < MaxDisplayListLength; i++)
+            {
+                
+                var firstWord = Config.Stream.GetUInt32(address);
+                var secondWord = Config.Stream.GetUInt32(address + 4);
+                var opcode = (F3DOpcode)((firstWord >> 24) & 0xFF);
+                var name = Enum.GetName(typeof(F3DOpcode), opcode);
+                res.AppendLine($"{firstWord:X8} {secondWord:X8} "+name);
+
+                if (opcode == F3DOpcode.G_ENDDL) break;
+                address += 4;
+            }
+
+            return res.ToString();
+        }
+
+        // A segmented address is 4 bytes. The first byte contains the index of the segment in the segment table, the 
+        // other 3 bytes are the offset from the segment. Segmented addresses are used for locating object behavior scripts, 
+        // display lists, textures and other resources.
+        // todo: not limited to Fast3D display lists, can be put in a more general utilitiies class
+        public static uint DecodeSegmentedAddress(uint address)
+        {
+            var val = Config.Stream.GetUInt32(address);
+            var offset = val & 0xFFFFFF;
+            var segment = (val >> 24) & 0xFF;
+            return offset + Config.Stream.GetUInt32(4 * segment + Config.SwitchRomVersion(0x33b400, 0x33A090));
+        }
+    }
+}

--- a/STROOP/Utilities/WatchVariableUtilities.cs
+++ b/STROOP/Utilities/WatchVariableUtilities.cs
@@ -166,6 +166,12 @@ namespace STROOP.Structs
                 case BaseAddressTypeEnum.CamHack:
                     return new List<uint> { CameraHackConfig.CameraHackStruct };
 
+                case BaseAddressTypeEnum.GfxNode:
+                    {
+                        var node  = Config.GfxManager.SelectedNode;
+                        return node != null ? new List<uint>() { node.address } : BaseAddressListEmpy;
+                    }
+
                 default:
                     throw new ArgumentOutOfRangeException();
             }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/14114684/36171330-80c693fa-1102-11e8-8889-e1354cdecc73.png)
Adds a Gfx tab which allows you to:
- Show the scene graph (see [How to Draw Mario: Introduction](https://www.youtube.com/watch?v=kYwYF3_p7Qs))
- Watch individual GFX nodes
- Decode display list nodes

Additionally, it updates the Bizhawk offset so that STROOP works with the newest version.

Still to do:
- Figure out all node types and members, give proper names
- Nicer UI, convenience features
- Identify models and textures
- (Possibly) refactor and put addresses of watch variables in XML file to be consistent with how other tabs manage them
